### PR TITLE
Salt and pepper test overhaul

### DIFF
--- a/attacks/foolboxattacks/salt_and_pepper.py
+++ b/attacks/foolboxattacks/salt_and_pepper.py
@@ -12,6 +12,8 @@ class SaltAndPepperNoise(SaltAndPepperNoiseAttack, FoolboxAttack):
     def conduct(self, model, data):
 
         model_correct_format = super().reformat_model(model)
+        if model_correct_format is None:
+            model_correct_format = model
 
         output = super().flatten_output(data)
         self.criterion = Misclassification(output)

--- a/tests/test_salt_and_pepper.py
+++ b/tests/test_salt_and_pepper.py
@@ -1,44 +1,109 @@
 from attacks.foolboxattacks.salt_and_pepper import SaltAndPepperNoise
 
+import time
 import mlflow
 import csv
 import numpy as np
 import torch
 
-class Data:
-    def __init__(self, x, y):
-        self.input = x
-        self.output = y
+import torchvision.models as tv_models
+import foolbox as fb
+from attacks.helpers.data import Data
+from attacks.foolbox_attack import FoolboxAttack
+from foolbox.utils import accuracy
+
+from foolbox.models.pytorch import PyTorchModel
 
 
-ss_nn_pipeline = mlflow.sklearn.load_model("ss_nn/")
-standard_scaler_from_nn_pipeline = ss_nn_pipeline.steps[0][1]
-nn_model = ss_nn_pipeline.steps[1][1].module_
+def simple_test(batchsize=40):
+    model = tv_models.resnet18(weights=tv_models.ResNet18_Weights.DEFAULT).eval()
+    preprocessing = dict(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225], axis=-3)
+    fmodel = fb.models.pytorch.PyTorchModel(model, bounds=(0, 1), preprocessing=preprocessing)
 
-attack_specific_args = {"steps": 5}
-generic_args = {}
-attack = SaltAndPepperNoise(attack_specific_args, generic_args)
+    images, labels = fb.utils.samples(fmodel, dataset='imagenet', batchsize=batchsize)
+    data = Data(images, labels)
 
-csv_filename = 'data_test.csv'
+    return fmodel, data
 
-with open(csv_filename) as f:
-    reader = csv.reader(f)
-    data = list(list(line) for line in reader)
-    data.pop(0)
-    data2 = []
-    for row in data:
-        row2 = []
-        for place in range(len(row)):
-            row2.append(float(row[place]))
-        data2.append(row2)
-    data = data2
-    data = torch.tensor(data, requires_grad=False, dtype=torch.float)
-    data, result = torch.hsplit(data, [91, ])
 
-    result = torch.tensor(result, requires_grad=False, dtype=torch.float)
-    data = Data(data, result)
+def nn_test():
+    ss_nn_pipeline = mlflow.sklearn.load_model('../ss_nn/')
+    if ss_nn_pipeline is not None:
+        standard_scaler_from_nn_pipeline = ss_nn_pipeline.steps[0][1]
+        nn_model = ss_nn_pipeline.steps[1][1].module_
+        fmodel = fb.models.pytorch.PyTorchModel(nn_model, bounds=(-2., 30000.))
 
-    print("Attack")
-    result = attack.conduct(nn_model, data)
-    print(result)
-    print("Done!")
+        csv_filename = '../data_test.csv'
+
+        with open(csv_filename) as f:
+            reader = csv.reader(f)
+            data = list(list(line) for line in reader)
+            data.pop(0)
+            data2 = []
+            i = 0
+            for row in data:
+                if i < 10000:
+                    i = i+1
+                    row2 = []
+                    for place in range(len(row)):
+                        row2.append(float(row[place]))
+                    data2.append(row2)
+            data = data2
+            data = torch.tensor(data, requires_grad=False, dtype=torch.float)
+            data, result = torch.hsplit(data, [91, ])
+            result = torch.tensor(result, requires_grad=False, dtype=torch.float)
+            data = Data(data, result)
+
+        return fmodel, data
+    return None, None
+
+
+def conduct(attack: SaltAndPepperNoise, model, data: Data):
+    time_start = time.time()
+
+    # print(type(model))
+    if isinstance(model, PyTorchModel):
+        print(f"Model accuracy before attack: {fb.utils.accuracy(model, data.input, data.output)}")
+    print(f"Starting attack. ({time.asctime(time.localtime(time_start))})")
+
+    adversarials = attack.conduct(model, data)
+
+    time_end = time.time()
+    print(f"Attack done. ({time.asctime(time.localtime(time_end))})")
+    print(f"Took {time_end - time_start}\n")
+
+    if adversarials is not None and isinstance(model, PyTorchModel):
+        print(f"Model accuracy after attack: {accuracy(model, adversarials, data.output)}")
+
+    return adversarials
+
+
+def main():
+    attack_specific_args_simple = {"steps": 10, "across_channels": False}
+    generic_args = {}
+
+    attack_specific_args_nn = {"steps": 1000, "across_channels": False}
+
+    attack_sap_simple = SaltAndPepperNoise(attack_specific_args_simple, generic_args)
+    attack_sap_nn = SaltAndPepperNoise(attack_specific_args_nn, generic_args)
+
+    smodel, sdata = simple_test(batchsize=4)
+
+    print("Attack salt and pepper simple with tiny batchsize")
+    result1s = conduct(attack_sap_simple, smodel, sdata)
+
+    smodel, sdata = simple_test(batchsize=20)
+
+    print("Attack salt and pepper simple with sligtly larger batchsize")
+    result2s = conduct(attack_sap_simple, smodel, sdata)
+
+
+    nn_model, nn_data = nn_test()
+    if nn_model is not None and nn_data is not None:
+        print("Attack salt and pepper nn")
+        result1nn = conduct(attack_sap_nn, nn_model, nn_data)
+
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Changed the salt and pepper noise attack test, so that it's similar to brendel bethge test, and so that it tests on multiple models and datasets. For some reason, it doesn't work on the nn model; I think binary classifier models are simply difficult to attack.