### PR TITLE
Foolbox attacks and tests changed

### DIFF
--- a/attack_manager.py
+++ b/attack_manager.py
@@ -14,8 +14,9 @@ from attacks.artattacks.adversarial_patch\
 # Ataki pochodzące z FoolBoxa
 from attacks.foolboxattacks.brendel_bethge import BrendelBethge 
 from attacks.foolboxattacks.basic_iterative import L1BasicIterative, L2BasicIterative, LinfBasicIterative
-from attacks.foolboxattacks.projected_gradient_descent\
-        import ProjectedGradientDescentInf
+from attacks.foolboxattacks.basic_iterative import L1AdamBasicIterative, L2AdamBasicIterative, LinfAdamBasicIterative
+from attacks.foolboxattacks.projected_gradient_descent import L1ProjectedGradientDescent, L2ProjectedGradientDescent, LinfProjectedGradientDescent
+from attacks.foolboxattacks.projected_gradient_descent import L1AdamProjectedGradientDescent, L2AdamProjectedGradientDescent, LinfAdamProjectedGradientDescent
 from attacks.foolboxattacks.salt_and_pepper import SaltAndPepperNoise
 
 
@@ -37,7 +38,15 @@ class AttackManager():
             "L1 Basic Iterative": L1BasicIterative,
             "L2 Basic Iterative": L2BasicIterative,
             "Linf Basic Iterative": LinfBasicIterative,
-            "Projected Gradient Descent Inf" : ProjectedGradientDescentInf,
+            "L1 Adam Basic Iterative": L1AdamBasicIterative,
+            "L2 Adam Basic Iterative": L2AdamBasicIterative,
+            "Linf Adam Basic Iterative": LinfAdamBasicIterative,
+            "L1 Projected Gradient Descent": L1ProjectedGradientDescent,
+            "L2 Projected Gradient Descent": L2ProjectedGradientDescent,
+            "Linf Projected Gradient Descent" : LinfProjectedGradientDescent,
+            "L1 Adam Projected Gradient Descent": L1AdamProjectedGradientDescent,
+            "L2 Adam Projected Gradient Descent": L2AdamProjectedGradientDescent,
+            "Linf Adam Projected Gradient Descent": LinfAdamProjectedGradientDescent,
             "Salt And Pepper" : SaltAndPepperNoise
         }
     

--- a/attacks/foolbox_attack.py
+++ b/attacks/foolbox_attack.py
@@ -10,10 +10,11 @@ class FoolboxAttack(Attack):
 
     def __init__(self, args):
         super().__init__()
-        self.criterion = args.get("criterion")
+        self.criterion_type = args.get("criterion_type", "misclassification")
         self.epsilon = args.get("epsilon", 0.01)
         self.min = args.get("min")
         self.max = args.get("max")
+        self.criterion = None
 
     @staticmethod
     def to_unified_format(data_from_attack):

--- a/attacks/foolboxattacks/basic_iterative.py
+++ b/attacks/foolboxattacks/basic_iterative.py
@@ -1,13 +1,13 @@
 from attacks.foolbox_attack import FoolboxAttack
-from foolbox.criteria import Misclassification
+from foolbox.criteria import Misclassification, TargetedMisclassification
 from foolbox.attacks.basic_iterative_method import L1BasicIterativeAttack, L2BasicIterativeAttack, LinfBasicIterativeAttack
 from foolbox.attacks.basic_iterative_method import L1AdamBasicIterativeAttack, L2AdamBasicIterativeAttack, LinfAdamBasicIterativeAttack
 
 
-class L1BasicIterative(L1BasicIterativeAttack, FoolboxAttack):
-    def __init__(self, attack_specific_args, generic_args):
-        super().__init__(**attack_specific_args)
-
+class GenericBasicIterative(FoolboxAttack):
+    def __init__(self, parent, attack_specific_args, generic_args):
+        self.Parent = parent
+        self.Parent.__init__(self, **attack_specific_args)
         FoolboxAttack.__init__(self, generic_args)
 
     def conduct(self, model, data):
@@ -17,101 +17,40 @@ class L1BasicIterative(L1BasicIterativeAttack, FoolboxAttack):
             model_correct_format = model
 
         output = super().flatten_output(data)
-        self.criterion = Misclassification(output)
+        if self.criterion_type == "targeted_misclassification":
+            self.criterion = TargetedMisclassification(output)
+        if self.criterion_type == "misclassification":
+            self.criterion = Misclassification(output)
 
-        result = super().run(model=model_correct_format, inputs=data.input, criterion=self.criterion, epsilon=self.epsilon)
+        result = self.Parent.run(self, model=model_correct_format, inputs=data.input, criterion=self.criterion, epsilon=self.epsilon)
         return result
 
 
-class L2BasicIterative(L2BasicIterativeAttack, FoolboxAttack):
+class L1BasicIterative(GenericBasicIterative, L1BasicIterativeAttack):
     def __init__(self, attack_specific_args, generic_args):
-        super().__init__(**attack_specific_args)
-
-        FoolboxAttack.__init__(self, generic_args)
-
-    def conduct(self, model, data):
-
-        model_correct_format = super().reformat_model(model)
-        if model_correct_format is None:
-            model_correct_format = model
-
-        output = super().flatten_output(data)
-        self.criterion = Misclassification(output)
-
-        result = super().run(model=model_correct_format, inputs=data.input, criterion=self.criterion, epsilon=self.epsilon)
-        return result
+        GenericBasicIterative.__init__(self, L1BasicIterativeAttack, attack_specific_args, generic_args)
 
 
-class LinfBasicIterative(LinfBasicIterativeAttack, FoolboxAttack):
+class L2BasicIterative(GenericBasicIterative, L2BasicIterativeAttack):
     def __init__(self, attack_specific_args, generic_args):
-        super().__init__(**attack_specific_args)
-
-        FoolboxAttack.__init__(self, generic_args)
-
-    def conduct(self, model, data):
-
-        model_correct_format = super().reformat_model(model)
-        if model_correct_format is None:
-            model_correct_format = model
-
-        output = super().flatten_output(data)
-        self.criterion = Misclassification(output)
-
-        result = super().run(model=model_correct_format, inputs=data.input, criterion=self.criterion, epsilon=self.epsilon)
-        return result
+        GenericBasicIterative.__init__(self, L2BasicIterativeAttack, attack_specific_args, generic_args)
 
 
-class L1AdamBasicIterative(L1AdamBasicIterativeAttack, FoolboxAttack):
+class LinfBasicIterative(GenericBasicIterative, LinfBasicIterativeAttack):
     def __init__(self, attack_specific_args, generic_args):
-        super().__init__(**attack_specific_args)
+        GenericBasicIterative.__init__(self, LinfBasicIterativeAttack, attack_specific_args, generic_args)
 
-        FoolboxAttack.__init__(self, generic_args)
 
-    def conduct(self, model, data):
-
-        model_correct_format = super().reformat_model(model)
-        if model_correct_format is None:
-            model_correct_format = model
-
-        output = super().flatten_output(data)
-        self.criterion = Misclassification(output)
-
-        result = super().run(model=model_correct_format, inputs=data.input, criterion=self.criterion, epsilon=self.epsilon)
-        return result
-
-class L2AdamBasicIterative(L2AdamBasicIterativeAttack, FoolboxAttack):
+class L1AdamBasicIterative(GenericBasicIterative, L1AdamBasicIterativeAttack):
     def __init__(self, attack_specific_args, generic_args):
-        super().__init__(**attack_specific_args)
-
-        FoolboxAttack.__init__(self, generic_args)
-
-    def conduct(self, model, data):
-
-        model_correct_format = super().reformat_model(model)
-        if model_correct_format is None:
-            model_correct_format = model
-
-        output = super().flatten_output(data)
-        self.criterion = Misclassification(output)
-
-        result = super().run(model=model_correct_format, inputs=data.input, criterion=self.criterion, epsilon=self.epsilon)
-        return result
+        GenericBasicIterative.__init__(self, L1AdamBasicIterativeAttack, attack_specific_args, generic_args)
 
 
-class LinfAdamBasicIterative(LinfAdamBasicIterativeAttack, FoolboxAttack):
+class L2AdamBasicIterative(GenericBasicIterative, L2AdamBasicIterativeAttack):
     def __init__(self, attack_specific_args, generic_args):
-        super().__init__(**attack_specific_args)
+        GenericBasicIterative.__init__(self, L2AdamBasicIterativeAttack, attack_specific_args, generic_args)
 
-        FoolboxAttack.__init__(self, generic_args)
 
-    def conduct(self, model, data):
-
-        model_correct_format = super().reformat_model(model)
-        if model_correct_format is None:
-            model_correct_format = model
-
-        output = super().flatten_output(data)
-        self.criterion = Misclassification(output)
-
-        result = super().run(model=model_correct_format, inputs=data.input, criterion=self.criterion, epsilon=self.epsilon)
-        return result
+class LinfAdamBasicIterative(GenericBasicIterative, LinfAdamBasicIterativeAttack):
+    def __init__(self, attack_specific_args, generic_args):
+        GenericBasicIterative.__init__(self, LinfAdamBasicIterativeAttack, attack_specific_args, generic_args)

--- a/attacks/foolboxattacks/brendel_bethge.py
+++ b/attacks/foolboxattacks/brendel_bethge.py
@@ -3,7 +3,7 @@ import traceback
 from foolbox.attacks.brendel_bethge import L0BrendelBethgeAttack, L1BrendelBethgeAttack, L2BrendelBethgeAttack, LinfinityBrendelBethgeAttack
 
 from attacks.foolbox_attack import FoolboxAttack
-from foolbox.criteria import Misclassification
+from foolbox.criteria import Misclassification, TargetedMisclassification
 from abc import ABC
 
 from attacks.helpers.data import Data
@@ -48,7 +48,10 @@ class BrendelBethge(FoolboxAttack, ABC):
             model_correct_format = model
         else:
             outputs = data.output[:, 0]
-        self.criterion = Misclassification(outputs)
+        if self.criterion_type == "targeted_misclassification":
+            self.criterion = TargetedMisclassification(outputs)
+        if self.criterion_type == "misclassification":
+            self.criterion = Misclassification(outputs)
 
 
         try:

--- a/attacks/foolboxattacks/projected_gradient_descent.py
+++ b/attacks/foolboxattacks/projected_gradient_descent.py
@@ -1,15 +1,56 @@
 from attacks.foolbox_attack import FoolboxAttack
-from foolbox.attacks import LinfPGD
+from foolbox.attacks import L1PGD,L2PGD,LinfPGD,L1AdamPGD,L2AdamPGD,LinfAdamPGD
+from foolbox.criteria import Misclassification, TargetedMisclassification
 
-# L -> inf
-class ProjectedGradientDescentInf(FoolboxAttack):
-    def __init__(self, **params):
-        super().__init__(params)
-        self._attack_params.update({'epsilons': [0.0]})
-        self._attack_params.update(params)
-        self._attack = LinfPGD()
-        self._model = None
+
+class GenericProjectedGradientDescent(FoolboxAttack):
+    def __init__(self, parent, attack_specific_args, generic_args):
+        self.Parent = parent
+        self.Parent.__init__(self, **attack_specific_args)
+        FoolboxAttack.__init__(self, generic_args)
 
     def conduct(self, model, data):
-        self._model = super().reformat_model(model)
-        return self.to_unified_format(self._attack(self._model, data.input, data.output, **self._attack_params))
+
+        model_correct_format = super().reformat_model(model)
+        if model_correct_format is None:
+            model_correct_format = model
+
+        output = super().flatten_output(data)
+        if self.criterion_type == "targeted_misclassification":
+            self.criterion = TargetedMisclassification(output)
+        if self.criterion_type == "misclassification":
+            self.criterion = Misclassification(output)
+
+        result = self.Parent.run(self, model=model_correct_format, inputs=data.input, criterion=self.criterion, epsilon=self.epsilon)
+        return result
+
+
+
+class L1ProjectedGradientDescent(GenericProjectedGradientDescent, L1PGD):
+    def __init__(self, attack_specific_args, generic_args):
+        GenericProjectedGradientDescent.__init__(self, L1PGD, attack_specific_args, generic_args)
+
+
+class L2ProjectedGradientDescent(GenericProjectedGradientDescent, L2PGD):
+    def __init__(self, attack_specific_args, generic_args):
+        GenericProjectedGradientDescent.__init__(self, L2PGD, attack_specific_args, generic_args)
+
+
+class LinfProjectedGradientDescent(GenericProjectedGradientDescent, LinfPGD):
+    def __init__(self, attack_specific_args, generic_args):
+        GenericProjectedGradientDescent.__init__(self, LinfPGD, attack_specific_args, generic_args)
+
+
+class L1AdamProjectedGradientDescent(GenericProjectedGradientDescent, L1AdamPGD):
+    def __init__(self, attack_specific_args, generic_args):
+        GenericProjectedGradientDescent.__init__(self, L1AdamPGD, attack_specific_args, generic_args)
+
+
+class L2AdamProjectedGradientDescent(GenericProjectedGradientDescent, L2AdamPGD):
+    def __init__(self, attack_specific_args, generic_args):
+        GenericProjectedGradientDescent.__init__(self, L2AdamPGD, attack_specific_args, generic_args)
+
+
+class LinfAdamProjectedGradientDescent(GenericProjectedGradientDescent, LinfAdamPGD):
+    def __init__(self, attack_specific_args, generic_args):
+        GenericProjectedGradientDescent.__init__(self, LinfAdamPGD, attack_specific_args, generic_args)

--- a/attacks/foolboxattacks/salt_and_pepper.py
+++ b/attacks/foolboxattacks/salt_and_pepper.py
@@ -1,5 +1,5 @@
 from attacks.foolbox_attack import FoolboxAttack
-from foolbox.criteria import Misclassification
+from foolbox.criteria import Misclassification, TargetedMisclassification
 from foolbox.attacks.saltandpepper import SaltAndPepperNoiseAttack
 
 
@@ -16,7 +16,10 @@ class SaltAndPepperNoise(SaltAndPepperNoiseAttack, FoolboxAttack):
             model_correct_format = model
 
         output = super().flatten_output(data)
-        self.criterion = Misclassification(output)
+        if self.criterion_type == "targeted_misclassification":
+            self.criterion = TargetedMisclassification(output)
+        if self.criterion_type == "misclassification":
+            self.criterion = Misclassification(output)
 
         result = super().run(model=model_correct_format, inputs=data.input, criterion=self.criterion)
         return result

--- a/tests/test_projected_gradient_descent.py
+++ b/tests/test_projected_gradient_descent.py
@@ -1,0 +1,142 @@
+import time
+import mlflow
+import csv
+import numpy as np
+import torch
+
+import torchvision.models as tv_models
+import foolbox as fb
+from attacks.foolboxattacks.projected_gradient_descent import L1ProjectedGradientDescent, L2ProjectedGradientDescent, LinfProjectedGradientDescent
+from attacks.foolboxattacks.projected_gradient_descent import L1AdamProjectedGradientDescent, L2AdamProjectedGradientDescent, LinfAdamProjectedGradientDescent
+from attacks.helpers.data import Data
+from attacks.foolbox_attack import FoolboxAttack
+from foolbox.utils import accuracy
+
+from foolbox.models.pytorch import PyTorchModel
+
+
+def simple_test(batchsize=4):
+    model = tv_models.resnet18(weights=tv_models.ResNet18_Weights.DEFAULT).eval()
+    preprocessing = dict(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225], axis=-3)
+    fmodel = fb.models.pytorch.PyTorchModel(model, bounds=(0, 1), preprocessing=preprocessing)
+
+    images, labels = fb.utils.samples(fmodel, dataset='imagenet', batchsize=batchsize)
+    data = Data(images, labels)
+
+    return fmodel, data
+
+
+def nn_test():
+    ss_nn_pipeline = mlflow.sklearn.load_model('../ss_nn/')
+    if ss_nn_pipeline is not None:
+        standard_scaler_from_nn_pipeline = ss_nn_pipeline.steps[0][1]
+        nn_model = ss_nn_pipeline.steps[1][1].module_
+
+        csv_filename = '../data_test.csv'
+
+        with open(csv_filename) as f:
+            reader = csv.reader(f)
+            data = list(list(line) for line in reader)
+            data.pop(0)
+            data2 = []
+            for row in data:
+                row2 = []
+                for place in range(len(row)):
+                    row2.append(float(row[place]))
+                data2.append(row2)
+            data = data2
+            data = torch.tensor(data, requires_grad=False, dtype=torch.float)
+            data, result = torch.hsplit(data, [91, ])
+            result = torch.tensor(result, requires_grad=False, dtype=torch.float)
+            data = Data(data, result)
+
+        return nn_model, data
+    return None, None
+
+
+def conduct(attack: FoolboxAttack, model, data: Data):
+    time_start = time.time()
+
+    # print(type(model))
+    if isinstance(model, PyTorchModel):
+        print(f"Model accuracy before attack: {fb.utils.accuracy(model, data.input, data.output)}")
+    print(f"Starting attack. ({time.asctime(time.localtime(time_start))})")
+
+    adversarials = attack.conduct(model, data)
+
+    time_end = time.time()
+    print(f"Attack done. ({time.asctime(time.localtime(time_end))})")
+    print(f"Took {time_end - time_start}\n")
+
+    if adversarials is not None and isinstance(model, PyTorchModel):
+        print(f"Model accuracy after attack: {accuracy(model, adversarials, data.output)}")
+
+    return adversarials
+
+
+def main():
+    attack_specific_args = {"steps": 10, "random_start": True}
+    generic_args = {"epsilon": 0.01}
+
+    attack_pgd1 = L1ProjectedGradientDescent(attack_specific_args, generic_args)
+    attack_pgd2 = L2ProjectedGradientDescent(attack_specific_args, generic_args)
+    attack_pgdinf = LinfProjectedGradientDescent(attack_specific_args, generic_args)
+    attack_pgd1_a = L1AdamProjectedGradientDescent(attack_specific_args, generic_args)
+    attack_pgd2_a = L2AdamProjectedGradientDescent(attack_specific_args, generic_args)
+    attack_pgdinf_a = LinfAdamProjectedGradientDescent(attack_specific_args, generic_args)
+
+    smodel, sdata = simple_test(batchsize=20)
+
+    print("Attack pgd1 simple")
+    result1s = conduct(attack_pgd1, smodel, sdata)
+    print(result1s)
+
+    print("Attack pgd2 simple")
+    result2s = conduct(attack_pgd2, smodel, sdata)
+    print(result2s)
+
+    print("Attack pgdinf simple")
+    resultinfs = conduct(attack_pgdinf, smodel, sdata)
+    print(resultinfs)
+
+    print("Attack pgd1 with Adam simple")
+    result1s = conduct(attack_pgd1_a, smodel, sdata)
+    print(result1s)
+
+    print("Attack pgd2 with Adam simple")
+    result2s = conduct(attack_pgd2_a, smodel, sdata)
+    print(result2s)
+
+    print("Attack pgdinf with Adam simple")
+    resultinfs = conduct(attack_pgdinf_a, smodel, sdata)
+    print(resultinfs)
+
+    nn_model, nn_data = nn_test()
+    if nn_model is not None and nn_data is not None:
+        print("Attack pgd1 nn")
+        result1nn = conduct(attack_pgd1, nn_model, nn_data)
+        print(result1nn)
+
+        print("Attack pgd2 nn")
+        result2nn = conduct(attack_pgd2, nn_model, nn_data)
+        print(result2nn)
+
+        print("Attack pgdinf nn")
+        resultinfnn = conduct(attack_pgdinf, nn_model, nn_data)
+        print(resultinfnn)
+
+        print("Attack pgd1 with Adam nn")
+        result1nn = conduct(attack_pgd1_a, nn_model, nn_data)
+        print(result1nn)
+
+        print("Attack pgd2 with Adam nn")
+        result2nn = conduct(attack_pgd2_a, nn_model, nn_data)
+        print(result2nn)
+
+        print("Attack pgdinf with Adam nn")
+        resultinfnn = conduct(attack_pgdinf_a, nn_model, nn_data)
+        print(resultinfnn)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- Changed the method of conducting foolbox attacks, so that they support targeted missclassification as a criterion
- Modified the basic iterative attack file, to remove redundancy
- Changed the projected gradient descent attack, so that it is implemented similarly to other foolbox attacks, and so that other types of projected gradient descent attack than the L_infinity are supported
- Added tests for the projected gradient descent attacks, adapted from those being used with the basic iterative attacks
- Added those new attacks to attack manager