### PR TITLE
Attack parameters overhaul

### DIFF
--- a/attacks/art_attack.py
+++ b/attacks/art_attack.py
@@ -20,28 +20,21 @@ class ARTAttack(Attack):
         return data_from_attack
 
     @abc.abstractmethod
-    def __init__(self, **params):
+    def __init__(self, params):
         super().__init__()
 
         # Parameters required to initialize the classifier
         self._classifier_params = {
-            'mask': None,
-            'reset_patch': False,
-            'input_shape': None,
-            'loss': None,
-            'nb_classes': None,
-            'optimizer': None,
-            'clip_values': None,
-            'use_logits': False
+            'mask': params.get('mask', None),
+            'reset_patch': params.get('reset_patch', False),
+            'input_shape': params.get('input_shape', None),
+            'loss': params.get('loss', None),
+            'nb_classes': params.get('nb_classes', None),
+            'optimizer': params.get('optimizer', None),
+            'clip_values': params.get('clip_values', None),
+            'use_logits': params.get('use_logits', False)
         }
 
-        # We separate known classifier parameters from potential attack params
-        for key in self._classifier_params.keys():
-            if key in params.keys():
-                self._classifier_params[key] = params[key]
-                params.pop(key)
-        # On lower levels we can separete further if needed
-        # There is no need to filter params on lower levels
 
     def _set_data(self, data):
         # TODO dorzucić tu lub wyżej sprawdzanie poprawności danych

--- a/attacks/art_attack.py
+++ b/attacks/art_attack.py
@@ -25,13 +25,13 @@ class ARTAttack(Attack):
 
         # Parameters required to initialize the classifier
         self._classifier_params = {
-            'mask': params.get('mask', None),
+            'mask': params.get('mask'),
             'reset_patch': params.get('reset_patch', False),
-            'input_shape': params.get('input_shape', None),
-            'loss': params.get('loss', None),
-            'nb_classes': params.get('nb_classes', None),
-            'optimizer': params.get('optimizer', None),
-            'clip_values': params.get('clip_values', None),
+            'input_shape': params.get('input_shape'),
+            'loss': params.get('loss'),
+            'nb_classes': params.get('nb_classes'),
+            'optimizer': params.get('optimizer'),
+            'clip_values': params.get('clip_values'),
             'use_logits': params.get('use_logits', False)
         }
 

--- a/attacks/artattacks/adversarial_patch.py
+++ b/attacks/artattacks/adversarial_patch.py
@@ -9,38 +9,31 @@ import numpy as np
 
 
 class AdversarialPatch(ARTAttack):
-    def __init__(self, **params):
-        super().__init__(**params)
+    def __init__(self, parameters):
+        super().__init__(parameters.classifier_parameters)
         self.attack = None
-        self._attack_params.update({
-            'classifier': None,
+        self._attack_params = {
+            "classifier": parameters.attack_parameters.get("classifier", None),
             # rotation_max (float) – The maximum rotation applied to random patches.
             # The value is expected to be in the range [0, 180].
-            'rotation_max': 22.5,
+            "rotation_max": parameters.attack_parameters.get("rotation_max", 22.5),
             # scale_min (float) – The minimum scaling applied to random patches.
             # The value should be in the range [0, 1], but less than scale_max.
-            'scale_min': 0.1,
-            'scale_max': 1.0,
+            "scale_min": parameters.attack_parameters.get("scale_min", 0.1),
+            "scale_max": parameters.attack_parameters.get("scale_max", 1.0),
             # learning_rate (float) – The learning rate of the optimization.
-            'learning_rate': 5.0,
+            "learning_rate": parameters.attack_parameters.get("learning_rate", 5.0),
             # max_iter (int) – The number of optimization steps.
-            'max_iter': 500,
+            "max_iter": parameters.attack_parameters.get("max_iter", 500),
             # batch_size (int) – The size of the training batch.
-            'batch_size': 16,
+            "batch_size": parameters.attack_parameters.get("batch_size", 16),
             # patch_shape – The shape of the adversarial patch as a tuple of shape (width, height, nb_channels).
             # Currently only supported for TensorFlowV2Classifier. For classifiers of other frameworks the patch_shape
             # is set to the shape of the input samples.
-            'patch_shape': None,
-            # targeted (bool) – Indicates whether the attack is targeted (True) or untargeted (False).
-            'targeted': True,
-            # verbose (bool) – Show progress bars.
-            'verbose': True,
-        })
-
-        # We do not include parameters outside the list!
-        for key in self._attack_params.keys():
-            if key in params.keys():
-                self._attack_params[key] = params[key]
+            "patch_shape": parameters.attack_parameters.get("patch_shape", None),
+            "targeted": parameters.attack_parameters.get("targeted", True),
+            "verbose": parameters.attack_parameters.get("verbose", True)
+        }
 
         self._attack: Union[AdversarialPatchTensorFlowV2, AdversarialPatchPyTorch, AdversarialPatchNumpy]
         if isinstance(self._attack_params.get('classifier'), TensorFlowV2Classifier):

--- a/attacks/artattacks/adversarial_patch.py
+++ b/attacks/artattacks/adversarial_patch.py
@@ -13,7 +13,7 @@ class AdversarialPatch(ARTAttack):
         super().__init__(parameters.classifier_parameters)
         self.attack = None
         self._attack_params = {
-            "classifier": parameters.attack_parameters.get("classifier", None),
+            "classifier": parameters.attack_parameters.get("classifier"),
             # rotation_max (float) – The maximum rotation applied to random patches.
             # The value is expected to be in the range [0, 180].
             "rotation_max": parameters.attack_parameters.get("rotation_max", 22.5),
@@ -30,7 +30,7 @@ class AdversarialPatch(ARTAttack):
             # patch_shape – The shape of the adversarial patch as a tuple of shape (width, height, nb_channels).
             # Currently only supported for TensorFlowV2Classifier. For classifiers of other frameworks the patch_shape
             # is set to the shape of the input samples.
-            "patch_shape": parameters.attack_parameters.get("patch_shape", None),
+            "patch_shape": parameters.attack_parameters.get("patch_shape"),
             "targeted": parameters.attack_parameters.get("targeted", True),
             "verbose": parameters.attack_parameters.get("verbose", True)
         }

--- a/attacks/artattacks/deep_fool.py
+++ b/attacks/artattacks/deep_fool.py
@@ -4,21 +4,16 @@ from attacks.art_attack import ARTAttack
 
 
 class DeepFool(ARTAttack):
-    def __init__(self, **params):
+    def __init__(self, parameters):
         # Initialization of the arguments needed for the classifier
-        super().__init__(**params)
+        super().__init__(parameters.classifier_parameters)
 
         self._attack_params = {
-            "max_iter": 100,
-            "epsilon": 1e-06,
-            "nb_grads": 10,
-            "verbose": True,
+            "max_iter": parameters.attack_parameters.get("max_iter", 100),
+            "epsilon": parameters.attack_parameters.get("epsilon", 1e-06),
+            "nb_grads": parameters.attack_parameters.get("nb_grads", 10),
+            "verbose": parameters.attack_parameters.get("verbose", True),
         }
-
-        # Assigning only relevant arguments
-        for key in self._attack_params.keys():
-            if key in params.keys():
-                self._attack_params[key] = params[key]
 
     def conduct(self, model, data):
         self._set_classifier(model)

--- a/attacks/artattacks/fast_gradient.py
+++ b/attacks/artattacks/fast_gradient.py
@@ -9,33 +9,29 @@ from attacks.art_attack import ARTAttack
 
 
 class FastGradient(ARTAttack):
-    def __init__(self, **params):
+    def __init__(self, parameters):
         # Initialization of the arguments needed for the classifier
-        super().__init__(**params)
+        super().__init__(parameters.classifier_parameters)
 
         self._attack_params = {
             # norm – The norm of the adversarial perturbation. Possible values: “inf”, np.inf, 1 or 2.
-            "norm": np.inf,
+            "norm": parameters.attack_parameters.get("norm", np.inf),
             # eps – Attack step size (input variation).
-            "eps": 0.3,
+            "eps": parameters.attack_parameters.get("eps", 0.3),
             # eps_step – Step size of input variation for minimal perturbation computation.
-            "eps_step": 0.1,
+            "eps_step": parameters.attack_parameters.get("eps_step", 0.1),
             # targeted (bool) – Indicates whether the attack is targeted (True) or untargeted (False).
-            "targeted": False,
+            "targeted": parameters.attack_parameters.get("targeted", False),
             # num_random_init (int) – Number of random initialisations within the epsilon ball.
-            "num_random_init": 0,
+            "num_random_init": parameters.attack_parameters.get("num_random_init", 0),
             # batch_size (int) – Size of the batch on which adversarial samples are generated.
-            "batch_size": 32,
+            "batch_size": parameters.attack_parameters.get("batch_size", 32),
             # minimal (bool) – Indicates if computing the minimal perturbation (True).
-            "minimal": False,
+            "minimal": parameters.attack_parameters.get("minimal", False),
             # summary_writer – Activate summary writer for TensorBoard.
-            "summary_writer": False
+            "summary_writer": parameters.attack_parameters.get("summary_writer", False),
         }
 
-        # Assigning only relevant arguments
-        for key in self._attack_params.keys():
-            if key in params.keys():
-                self._attack_params[key] = params[key]
 
     def conduct(self, model, data):
         self._set_classifier(model)

--- a/attacks/artattacks/joker.py
+++ b/attacks/artattacks/joker.py
@@ -7,19 +7,10 @@ from attacks.art_attack import ARTAttack
 from art.attacks.evasion import *
 
 class Joker(ARTAttack):
-    def __init__(self, **params):
-        if 'joker' not in params:
-            raise Exception("The joker parameter is mandatory, set it to the name of the desired class from ART")
-
-        # Initialization of the arguments needed for the classifier
-        super().__init__(**params)
-
-        for key in self._classifier_params:
-            if key in params:
-                params.pop(key)
-
-        self.joker = params.pop('joker')
-        self._attack_params = params
+    def __init__(self, joker, parameters):
+        self.joker=joker
+        super().__init__(parameters.classifier_parameters)
+        self._attack_params = parameters.attack_parameters
 
     def conduct(self, model, data):
         self._set_classifier(model)

--- a/attacks/artattacks/zeroth_order_optimization_bb_attack.py
+++ b/attacks/artattacks/zeroth_order_optimization_bb_attack.py
@@ -4,45 +4,37 @@ from art.attacks.evasion import ZooAttack as orig_art_zoo_attack
 
 
 class ZeorthOrderOptimalization(ARTAttack):
-    def __init__(self, **params):
+    def __init__(self, parameters):
         # inicjalizacja argumentów potrzebnych dla klasyfikatora, będą one wspólne dla wszystkich ataków
-        super().__init__(**params)
+        super().__init__(parameters.classifier_parameters)
         # Definiujemy podstawowe parametry ataku
-        self._attack_params.update({
+        self._attack_params = {
             # Pewność przykładów kontradyktoryjnych
-            'confidence': 0.0,
+            "confidence": parameters.attack_parameters.get("confidence", 0.0),
             # Czy atak ma sie skupić na konkrentej klasie
-            'targeted': False,
+            "targeted": parameters.attack_parameters.get("targeted", False),
             # mniej => lepsze wyniki ale dłużej
-            'learning_rate': 0.01,
+            "learning_rate": parameters.attack_parameters.get("learning_rate", 0.01),
             # To można zwiększyć
-            'max_iter': 10,
+            "max_iter": parameters.attack_parameters.get("max_iter", 10),
             # To również
-            'binary_search_steps': 1,
+            "binary_search_steps": parameters.attack_parameters.get("binary_search_steps", 1),
             # To nie ma znaczenia, gdy powyższe jest 'duże'
-            'initial_const': 0.001,
+            "initial_const": parameters.attack_parameters.get("initial_const", 0.001),
             # Czy w przypadku 'utknięcia' przerwać wcześniej
-            'abort_early': True,
-
-            'use_resize': True,
-
-            'use_importance': True,
+            "abort_early": parameters.attack_parameters.get("abort_early", True),
+            "use_resize": parameters.attack_parameters.get("use_resize", True),
+            "use_importance": parameters.attack_parameters.get("use_importance", True),
             # To można chyba podkręcić
-            'nb_parallel': 128,
-            # Wielkość grup próbek (warto zwrócić uwagę, że wykonywanych jest
-            # nb_parallel na raz, stąd nie powinno być bardzo duże)
-            'batch_size': 1,
+            "nb_parallel": parameters.attack_parameters.get("nb_parallel", 128),
+            # Wielkość grup próbek (warto zwrócić uwagę, że wykonywanych jest nb_parallel na raz, stąd nie powinno być bardzo duże)
+            "batch_size": parameters.attack_parameters.get("batch_size", 1),
             # Zmienna używana do numerycznego przybliżenia pochodnej
-            'variable_h': 0.0001,
+            "variable_h": parameters.attack_parameters.get("variable_h", 0.0001),
             # Czy pokazywać pasek progresu
-            'verbose': False
-        })
-        # Jeśli podano inne to podmieniamy, ale nie uwzględniamy
-        # parametrów spoza listy!
+            "verbose": parameters.attack_parameters.get("verbose", False),
+        }
 
-        for key in self._attack_params.keys():
-            if key in params.keys():
-                self._attack_params[key] = params[key]
 
 
     def conduct(self, model, data):

--- a/attacks/foolboxattacks/basic_iterative.py
+++ b/attacks/foolboxattacks/basic_iterative.py
@@ -4,19 +4,23 @@ from foolbox.attacks.basic_iterative_method import L1BasicIterativeAttack, L2Bas
 from foolbox.attacks.basic_iterative_method import L1AdamBasicIterativeAttack, L2AdamBasicIterativeAttack, LinfAdamBasicIterativeAttack
 
 
+
 class GenericBasicIterative(FoolboxAttack):
-    def __init__(self, parent, attack_specific_args, generic_args):
+    def __init__(self, parent, parameters):
         self.Parent = parent
-        self.Parent.__init__(self, **attack_specific_args)
-        FoolboxAttack.__init__(self, generic_args)
+        self.Parent.__init__(self, **parameters.attack_specific_parameters)
+        FoolboxAttack.__init__(self, parameters.generic_parameters)
+
+
 
     def conduct(self, model, data):
-
+        output = super().flatten_output(data)
+        super().verify_bounds(data=data)
+        super().verify_epsilon()
         model_correct_format = super().reformat_model(model)
         if model_correct_format is None:
             model_correct_format = model
 
-        output = super().flatten_output(data)
         if self.criterion_type == "targeted_misclassification":
             self.criterion = TargetedMisclassification(output)
         if self.criterion_type == "misclassification":
@@ -27,30 +31,30 @@ class GenericBasicIterative(FoolboxAttack):
 
 
 class L1BasicIterative(GenericBasicIterative, L1BasicIterativeAttack):
-    def __init__(self, attack_specific_args, generic_args):
-        GenericBasicIterative.__init__(self, L1BasicIterativeAttack, attack_specific_args, generic_args)
+    def __init__(self, parameters):
+        GenericBasicIterative.__init__(self, L1BasicIterativeAttack, parameters)
 
 
 class L2BasicIterative(GenericBasicIterative, L2BasicIterativeAttack):
-    def __init__(self, attack_specific_args, generic_args):
-        GenericBasicIterative.__init__(self, L2BasicIterativeAttack, attack_specific_args, generic_args)
+    def __init__(self, parameters):
+        GenericBasicIterative.__init__(self, L2BasicIterativeAttack, parameters)
 
 
 class LinfBasicIterative(GenericBasicIterative, LinfBasicIterativeAttack):
-    def __init__(self, attack_specific_args, generic_args):
-        GenericBasicIterative.__init__(self, LinfBasicIterativeAttack, attack_specific_args, generic_args)
+    def __init__(self, parameters):
+        GenericBasicIterative.__init__(self, LinfBasicIterativeAttack, parameters)
 
 
 class L1AdamBasicIterative(GenericBasicIterative, L1AdamBasicIterativeAttack):
-    def __init__(self, attack_specific_args, generic_args):
-        GenericBasicIterative.__init__(self, L1AdamBasicIterativeAttack, attack_specific_args, generic_args)
+    def __init__(self, parameters):
+        GenericBasicIterative.__init__(self, L1AdamBasicIterativeAttack, parameters)
 
 
 class L2AdamBasicIterative(GenericBasicIterative, L2AdamBasicIterativeAttack):
-    def __init__(self, attack_specific_args, generic_args):
-        GenericBasicIterative.__init__(self, L2AdamBasicIterativeAttack, attack_specific_args, generic_args)
+    def __init__(self, parameters):
+        GenericBasicIterative.__init__(self, L2AdamBasicIterativeAttack, parameters)
 
 
 class LinfAdamBasicIterative(GenericBasicIterative, LinfAdamBasicIterativeAttack):
-    def __init__(self, attack_specific_args, generic_args):
-        GenericBasicIterative.__init__(self, LinfAdamBasicIterativeAttack, attack_specific_args, generic_args)
+    def __init__(self, parameters):
+        GenericBasicIterative.__init__(self, LinfAdamBasicIterativeAttack, parameters)

--- a/attacks/foolboxattacks/projected_gradient_descent.py
+++ b/attacks/foolboxattacks/projected_gradient_descent.py
@@ -1,21 +1,25 @@
 from attacks.foolbox_attack import FoolboxAttack
 from foolbox.attacks import L1PGD,L2PGD,LinfPGD,L1AdamPGD,L2AdamPGD,LinfAdamPGD
 from foolbox.criteria import Misclassification, TargetedMisclassification
+from attacks.helpers.data import Data
+from eagerpy.astensor import astensor
 
 
 class GenericProjectedGradientDescent(FoolboxAttack):
-    def __init__(self, parent, attack_specific_args, generic_args):
+    def __init__(self, parent, parameters):
         self.Parent = parent
-        self.Parent.__init__(self, **attack_specific_args)
-        FoolboxAttack.__init__(self, generic_args)
+        self.Parent.__init__(self, **parameters.attack_specific_parameters)
+        FoolboxAttack.__init__(self, parameters.generic_parameters)
 
     def conduct(self, model, data):
 
+        output = super().flatten_output(data)
+        super().verify_bounds(data=data)
+        super().verify_epsilon()
         model_correct_format = super().reformat_model(model)
         if model_correct_format is None:
             model_correct_format = model
 
-        output = super().flatten_output(data)
         if self.criterion_type == "targeted_misclassification":
             self.criterion = TargetedMisclassification(output)
         if self.criterion_type == "misclassification":
@@ -27,30 +31,30 @@ class GenericProjectedGradientDescent(FoolboxAttack):
 
 
 class L1ProjectedGradientDescent(GenericProjectedGradientDescent, L1PGD):
-    def __init__(self, attack_specific_args, generic_args):
-        GenericProjectedGradientDescent.__init__(self, L1PGD, attack_specific_args, generic_args)
+    def __init__(self, parameters):
+        GenericProjectedGradientDescent.__init__(self, L1PGD, parameters)
 
 
 class L2ProjectedGradientDescent(GenericProjectedGradientDescent, L2PGD):
-    def __init__(self, attack_specific_args, generic_args):
-        GenericProjectedGradientDescent.__init__(self, L2PGD, attack_specific_args, generic_args)
+    def __init__(self, parameters):
+        GenericProjectedGradientDescent.__init__(self, L2PGD, parameters)
 
 
 class LinfProjectedGradientDescent(GenericProjectedGradientDescent, LinfPGD):
-    def __init__(self, attack_specific_args, generic_args):
-        GenericProjectedGradientDescent.__init__(self, LinfPGD, attack_specific_args, generic_args)
+    def __init__(self, parameters):
+        GenericProjectedGradientDescent.__init__(self, LinfPGD, parameters)
 
 
 class L1AdamProjectedGradientDescent(GenericProjectedGradientDescent, L1AdamPGD):
-    def __init__(self, attack_specific_args, generic_args):
-        GenericProjectedGradientDescent.__init__(self, L1AdamPGD, attack_specific_args, generic_args)
+    def __init__(self, parameters):
+        GenericProjectedGradientDescent.__init__(self, L1AdamPGD, parameters)
 
 
 class L2AdamProjectedGradientDescent(GenericProjectedGradientDescent, L2AdamPGD):
-    def __init__(self, attack_specific_args, generic_args):
-        GenericProjectedGradientDescent.__init__(self, L2AdamPGD, attack_specific_args, generic_args)
+    def __init__(self, parameters):
+        GenericProjectedGradientDescent.__init__(self, L2AdamPGD, parameters)
 
 
 class LinfAdamProjectedGradientDescent(GenericProjectedGradientDescent, LinfAdamPGD):
-    def __init__(self, attack_specific_args, generic_args):
-        GenericProjectedGradientDescent.__init__(self, LinfAdamPGD, attack_specific_args, generic_args)
+    def __init__(self, parameters):
+        GenericProjectedGradientDescent.__init__(self, LinfAdamPGD, parameters)

--- a/attacks/foolboxattacks/salt_and_pepper.py
+++ b/attacks/foolboxattacks/salt_and_pepper.py
@@ -4,18 +4,19 @@ from foolbox.attacks.saltandpepper import SaltAndPepperNoiseAttack
 
 
 class SaltAndPepperNoise(SaltAndPepperNoiseAttack, FoolboxAttack):
-    def __init__(self, attack_specific_args, generic_args):
-
-        super().__init__(**attack_specific_args)
-        FoolboxAttack.__init__(self, generic_args)
+    def __init__(self, parameters):
+        super().__init__(**parameters.attack_specific_parameters)
+        FoolboxAttack.__init__(self, parameters.generic_parameters)
 
     def conduct(self, model, data):
 
+        output = super().flatten_output(data)
+        super().verify_bounds(data=data)
+        super().verify_epsilon()
         model_correct_format = super().reformat_model(model)
         if model_correct_format is None:
             model_correct_format = model
 
-        output = super().flatten_output(data)
         if self.criterion_type == "targeted_misclassification":
             self.criterion = TargetedMisclassification(output)
         if self.criterion_type == "misclassification":

--- a/attacks/helpers/parameters.py
+++ b/attacks/helpers/parameters.py
@@ -1,0 +1,7 @@
+class FoolboxParameters:
+    def __init__(self, attack_specific_parameters, generic_parameters):
+        self.attack_specific_parameters = attack_specific_parameters
+        self.generic_parameters = generic_parameters
+
+#class ARTParameters:
+#    def __init__(self, parameters):

--- a/attacks/helpers/parameters.py
+++ b/attacks/helpers/parameters.py
@@ -1,7 +1,12 @@
-class FoolboxParameters:
+class Parameter:
+    pass
+
+class FoolboxParameters(Parameter):
     def __init__(self, attack_specific_parameters, generic_parameters):
         self.attack_specific_parameters = attack_specific_parameters
         self.generic_parameters = generic_parameters
 
-#class ARTParameters:
-#    def __init__(self, parameters):
+class ARTParameters(Parameter):
+    def __init__(self, classifier_parameters, attack_parameters):
+        self.classifier_parameters=classifier_parameters
+        self.attack_parameters=attack_parameters

--- a/tests/test_art_class_zoo.py
+++ b/tests/test_art_class_zoo.py
@@ -8,6 +8,7 @@ from attacks.art_attack import ARTAttack
 
 from attacks.artattacks.zeroth_order_optimization_bb_attack\
     import ZeorthOrderOptimalization as ZOOAttack
+from attacks.helpers.parameters import ARTParameters
 
 class TestZOO(unittest.TestCase):
     def test_class_hierarchy(self):
@@ -27,7 +28,7 @@ class TestZOO(unittest.TestCase):
 
         print("Próba utowrzenia obiektu klasy ARTAttack:\n****")
         try:
-            AbsA = ARTAttack()
+            AbsA = ARTAttack({})
             assertion_var += 1
             print("Brak błędów.")
         except Exception as e:
@@ -39,7 +40,7 @@ class TestZOO(unittest.TestCase):
 
         print("Klasę konkretnego ataku można już zinstancjonować:\n****")
         try:
-            ZOO_attack = ZOOAttack()
+            ZOO_attack = ZOOAttack(ARTParameters({}, {}))
             assertion_var += 1
             print("Brak błędów.")
         except Exception as e:
@@ -51,10 +52,11 @@ class TestZOO(unittest.TestCase):
 
         default_params = ZOO_attack._attack_params
 
-        ZOO_attack = ZOOAttack(confidence=0.50, abort_early=False, max_iter=100, boi_o_boi="YES")
+        attack_parameters={"confidence": 0.5, "abort_early": False, "max_iter": 100}
+
+        ZOO_attack = ZOOAttack(ARTParameters(classifier_parameters={}, attack_parameters=attack_parameters))
         changed_params = ZOO_attack._attack_params
 
-        self.assertNotIn('boi_o_boi', changed_params.keys())
 
         for key, val in default_params.items():
             if changed_params[key] != val:

--- a/tests/test_basic_iterative.py
+++ b/tests/test_basic_iterative.py
@@ -8,10 +8,10 @@ import torchvision.models as tv_models
 import foolbox as fb
 from attacks.foolboxattacks.basic_iterative import L1BasicIterative, L2BasicIterative, LinfBasicIterative
 from attacks.foolboxattacks.basic_iterative import L1AdamBasicIterative, L2AdamBasicIterative, LinfAdamBasicIterative
+from attacks.helpers.parameters import FoolboxParameters
 from attacks.helpers.data import Data
 from attacks.foolbox_attack import FoolboxAttack
 from foolbox.utils import accuracy
-
 from foolbox.models.pytorch import PyTorchModel
 
 
@@ -75,15 +75,16 @@ def conduct(attack: FoolboxAttack, model, data: Data):
 
 
 def main():
-    attack_specific_args = {"steps": 10, "random_start": True}
-    generic_args = {"epsilon": 20}
+    attack_specific_parameters = {"steps": 10, "random_start": True}
+    generic_parameters = {"epsilon_rate": 0.01}
+    parameters = FoolboxParameters(attack_specific_parameters, generic_parameters)
 
-    attack_bi1 = L1BasicIterative(attack_specific_args, generic_args)
-    attack_bi2 = L2BasicIterative(attack_specific_args, generic_args)
-    attack_biinf = LinfBasicIterative(attack_specific_args, generic_args)
-    attack_bi1_a = L1AdamBasicIterative(attack_specific_args, generic_args)
-    attack_bi2_a = L2AdamBasicIterative(attack_specific_args, generic_args)
-    attack_biinf_a = LinfAdamBasicIterative(attack_specific_args, generic_args)
+    attack_bi1 = L1BasicIterative(parameters)
+    attack_bi2 = L2BasicIterative(parameters)
+    attack_biinf = LinfBasicIterative(parameters)
+    attack_bi1_a = L1AdamBasicIterative(parameters)
+    attack_bi2_a = L2AdamBasicIterative(parameters)
+    attack_biinf_a = LinfAdamBasicIterative(parameters)
 
     smodel, sdata = simple_test(batchsize=20)
 

--- a/tests/test_basic_iterative.py
+++ b/tests/test_basic_iterative.py
@@ -2,7 +2,8 @@ import time
 import mlflow
 import csv
 import numpy as np
-import torchimport unittest
+import torch
+import unittest
 
 import torchvision.models as tv_models
 import foolbox as fb

--- a/tests/test_basic_iterative.py
+++ b/tests/test_basic_iterative.py
@@ -92,51 +92,51 @@ class TestBasicIterative(unittest.TestCase):
 
     def test_bi_1_simple(self):
         result1s = conduct(self.attack_bi1, self.smodel, self.sdata)
-        #print(result1s)
+        self.assertIsNotNone(result1s)
 
     def test_bi_2_simple(self):
         result2s = conduct(self.attack_bi2, self.smodel, self.sdata)
-        #print(result2s)
+        self.assertIsNotNone(result2s)
 
     def test_bi_inf_simple(self):
         resultinfs = conduct(self.attack_biinf, self.smodel, self.sdata)
-        #print(resultinfs)
+        self.assertIsNotNone(resultinfs)
 
     def test_bi_1_a_simple(self):
         result1s = conduct(self.attack_bi1_a, self.smodel, self.sdata)
-        # print(result1s)
+        self.assertIsNotNone(result1s)
 
     def test_bi_2_a_simple(self):
         result2s = conduct(self.attack_bi2_a, self.smodel, self.sdata)
-        # print(result2s)
+        self.assertIsNotNone(result2s)
 
     def test_bi_inf_a_simple(self):
         resultinfs = conduct(self.attack_biinf_a, self.smodel, self.sdata)
-        # print(resultinfs)
+        self.assertIsNotNone(resultinfs)
 
     nn_model, nn_data = nn_test()
 
     def test_bi_1_nn(self):
         result1nn = conduct(self.attack_bi1, self.nn_model, self.nn_data)
-        # print(result1nn)
+        self.assertIsNotNone(result1nn)
 
     def test_bi_2_nn(self):
         result2nn = conduct(self.attack_bi2, self.nn_model, self.nn_data)
-        # print(result2nn)
+        self.assertIsNotNone(result2nn)
 
     def test_bi_inf_nn(self):
         resultinfnn = conduct(self.attack_biinf, self.nn_model, self.nn_data)
-        # print(resultinfnn)
+        self.assertIsNotNone(resultinfnn)
 
     def test_bi_1_a_nn(self):
         result1ann = conduct(self.attack_bi1_a, self.nn_model, self.nn_data)
-        # print(result1ann)
+        self.assertIsNotNone(result1ann)
 
     def test_bi_2_a_nn(self):
         result2ann = conduct(self.attack_bi2_a, self.nn_model, self.nn_data)
-        # print(result2ann)
+        self.assertIsNotNone(result2ann)
 
     def test_bi_inf_a_nn(self):
         resultinfann = conduct(self.attack_biinf_a, self.nn_model, self.nn_data)
-        # print(resultinfann)
+        self.assertIsNotNone(resultinfann)
 

--- a/tests/test_basic_iterative.py
+++ b/tests/test_basic_iterative.py
@@ -2,7 +2,7 @@ import time
 import mlflow
 import csv
 import numpy as np
-import torch
+import torchimport unittest
 
 import torchvision.models as tv_models
 import foolbox as fb
@@ -13,6 +13,7 @@ from attacks.helpers.data import Data
 from attacks.foolbox_attack import FoolboxAttack
 from foolbox.utils import accuracy
 from foolbox.models.pytorch import PyTorchModel
+
 
 
 def simple_test(batchsize=4):
@@ -74,7 +75,7 @@ def conduct(attack: FoolboxAttack, model, data: Data):
     return adversarials
 
 
-def main():
+class TestBasicIterative(unittest.TestCase):
     attack_specific_parameters = {"steps": 10, "random_start": True}
     generic_parameters = {"epsilon_rate": 0.01}
     parameters = FoolboxParameters(attack_specific_parameters, generic_parameters)
@@ -88,56 +89,53 @@ def main():
 
     smodel, sdata = simple_test(batchsize=20)
 
-    print("Attack bi1 simple")
-    result1s = conduct(attack_bi1, smodel, sdata)
-    print(result1s)
+    def test_bi_1_simple(self):
+        result1s = conduct(self.attack_bi1, self.smodel, self.sdata)
+        #print(result1s)
 
-    print("Attack bi2 simple")
-    result2s = conduct(attack_bi2, smodel, sdata)
-    print(result2s)
+    def test_bi_2_simple(self):
+        result2s = conduct(self.attack_bi2, self.smodel, self.sdata)
+        #print(result2s)
 
-    print("Attack biinf simple")
-    resultinfs = conduct(attack_biinf, smodel, sdata)
-    print(resultinfs)
+    def test_bi_inf_simple(self):
+        resultinfs = conduct(self.attack_biinf, self.smodel, self.sdata)
+        #print(resultinfs)
 
-    print("Attack bi1 with Adam simple")
-    result1s = conduct(attack_bi1_a, smodel, sdata)
-    print(result1s)
+    def test_bi_1_a_simple(self):
+        result1s = conduct(self.attack_bi1_a, self.smodel, self.sdata)
+        # print(result1s)
 
-    print("Attack bi2 with Adam simple")
-    result2s = conduct(attack_bi2_a, smodel, sdata)
-    print(result2s)
+    def test_bi_2_a_simple(self):
+        result2s = conduct(self.attack_bi2_a, self.smodel, self.sdata)
+        # print(result2s)
 
-    print("Attack biinf with Adam simple")
-    resultinfs = conduct(attack_biinf_a, smodel, sdata)
-    print(resultinfs)
+    def test_bi_inf_a_simple(self):
+        resultinfs = conduct(self.attack_biinf_a, self.smodel, self.sdata)
+        # print(resultinfs)
 
     nn_model, nn_data = nn_test()
-    if nn_model is not None and nn_data is not None:
-        print("Attack bi1 nn")
-        result1nn = conduct(attack_bi1, nn_model, nn_data)
-        print(result1nn)
 
-        print("Attack bi2 nn")
-        result2nn = conduct(attack_bi2, nn_model, nn_data)
-        print(result2nn)
+    def test_bi_1_nn(self):
+        result1nn = conduct(self.attack_bi1, self.nn_model, self.nn_data)
+        # print(result1nn)
 
-        print("Attack biinf nn")
-        resultinfnn = conduct(attack_biinf, nn_model, nn_data)
-        print(resultinfnn)
+    def test_bi_2_nn(self):
+        result2nn = conduct(self.attack_bi2, self.nn_model, self.nn_data)
+        # print(result2nn)
 
-        print("Attack bi1 with Adam nn")
-        result1nn = conduct(attack_bi1_a, nn_model, nn_data)
-        print(result1nn)
+    def test_bi_inf_nn(self):
+        resultinfnn = conduct(self.attack_biinf, self.nn_model, self.nn_data)
+        # print(resultinfnn)
 
-        print("Attack bi2 with Adam nn")
-        result2nn = conduct(attack_bi2_a, nn_model, nn_data)
-        print(result2nn)
+    def test_bi_1_a_nn(self):
+        result1ann = conduct(self.attack_bi1_a, self.nn_model, self.nn_data)
+        # print(result1ann)
 
-        print("Attack biinf with Adam nn")
-        resultinfnn = conduct(attack_biinf_a, nn_model, nn_data)
-        print(resultinfnn)
+    def test_bi_2_a_nn(self):
+        result2ann = conduct(self.attack_bi2_a, self.nn_model, self.nn_data)
+        # print(result2ann)
 
+    def test_bi_inf_a_nn(self):
+        resultinfann = conduct(self.attack_biinf_a, self.nn_model, self.nn_data)
+        # print(resultinfann)
 
-if __name__ == '__main__':
-    main()

--- a/tests/test_brendel_bethge.py
+++ b/tests/test_brendel_bethge.py
@@ -3,6 +3,7 @@ import mlflow
 import csv
 import numpy as np
 import torch
+import unittest
 
 import torchvision.models as tv_models
 import foolbox as fb
@@ -78,7 +79,7 @@ def conduct(attack: FoolboxAttack, model, data: Data):
 
 
         
-def main():
+class TestBrendelBethge(unittest.TestCase):
     generic_parameters_simple = {'min': 0, 'max': 1}
     generic_parameters_nn = {'min': -1.0, 'max': 28157.0}
     attack_specific_parameters = {"lr": 10, 'steps': 100}
@@ -97,39 +98,37 @@ def main():
 
     smodel, sdata = simple_test()
 
-    print("Attack bb0 simple")
-    result0s = conduct(attack_bb0_simple, smodel, sdata)
-    print(result0s)
+    def test_bb_0_simple(self):
+        result0s = conduct(self.attack_bb0_simple, self.smodel, self.sdata)
+        #print(result0s)
 
-    print("Attack bb1 simple")
-    result1 = conduct(attack_bb1_simple, smodel, sdata)
-    print(result1)
+    def test_bb_1_simple(self):
+        result1s = conduct(self.attack_bb1_simple, self.smodel, self.sdata)
+        #print(result1s)
 
-    print("Attack bb2 simple")
-    result2s = conduct(attack_bb2_simple, smodel, sdata)
-    print(result2s)
+    def test_bb_2_simple(self):
+        result2s = conduct(self.attack_bb2_simple, self.smodel, self.sdata)
+        #print(result2s)
 
-    print("Attack bbinf simple")
-    resultinfs = conduct(attack_bbinf_simple, smodel, sdata)
-    print(resultinfs)
+    def test_bb_inf_simple(self):
+        resultinfs = conduct(self.attack_bbinf_simple, self.smodel, self.sdata)
+        #print(resultinfs)
 
     nn_model, nn_data = nn_test()
-    if nn_model is not None and nn_data is not None:
-        print("Attack bb0 nn")
-        result0nn = conduct(attack_bb0_nn, nn_model, nn_data)
-        print(result0nn)
 
-        print("Attack bb1 nn")
-        result1nn = conduct(attack_bb1_nn, nn_model, nn_data)
-        print(result1nn)
-        
-        print("Attack bb2 nn")
-        result2nn = conduct(attack_bb2_nn, nn_model, nn_data)
-        print(result2nn)
-        
-        print("Attack bbinf nn")
-        resultinfnn = conduct(attack_bbinf_nn, nn_model, nn_data)
-        print(resultinfnn)
+    def test_bb_0_nn(self):
+        result0nn = conduct(self.attack_bb0_nn, self.nn_model, self.nn_data)
+        #print(result0nn)
 
-if __name__ == '__main__':
-    main()
+    def test_bb_1_nn(self):
+        result1nn = conduct(self.attack_bb1_nn, self.nn_model, self.nn_data)
+        #print(result1nn)
+
+    def test_bb_2_nn(self):
+        result2nn = conduct(self.attack_bb2_nn, self.nn_model, self.nn_data)
+        #print(result2nn)
+
+    def test_bb_inf_nn(self):
+        resultinfnn = conduct(self.attack_bbinf_nn, self.nn_model, self.nn_data)
+        #print(resultinfnn)
+

--- a/tests/test_brendel_bethge.py
+++ b/tests/test_brendel_bethge.py
@@ -100,35 +100,35 @@ class TestBrendelBethge(unittest.TestCase):
 
     def test_bb_0_simple(self):
         result0s = conduct(self.attack_bb0_simple, self.smodel, self.sdata)
-        #print(result0s)
+        self.assertIsNotNone(result0s)
 
     def test_bb_1_simple(self):
         result1s = conduct(self.attack_bb1_simple, self.smodel, self.sdata)
-        #print(result1s)
+        self.assertIsNotNone(result1s)
 
     def test_bb_2_simple(self):
         result2s = conduct(self.attack_bb2_simple, self.smodel, self.sdata)
-        #print(result2s)
+        self.assertIsNotNone(result2s)
 
     def test_bb_inf_simple(self):
         resultinfs = conduct(self.attack_bbinf_simple, self.smodel, self.sdata)
-        #print(resultinfs)
+        self.assertIsNotNone(resultinfs)
 
     nn_model, nn_data = nn_test()
 
     def test_bb_0_nn(self):
         result0nn = conduct(self.attack_bb0_nn, self.nn_model, self.nn_data)
-        #print(result0nn)
+        self.assertIsNotNone(result0nn)
 
     def test_bb_1_nn(self):
         result1nn = conduct(self.attack_bb1_nn, self.nn_model, self.nn_data)
-        #print(result1nn)
+        self.assertIsNotNone(result1nn)
 
     def test_bb_2_nn(self):
         result2nn = conduct(self.attack_bb2_nn, self.nn_model, self.nn_data)
-        #print(result2nn)
+        self.assertIsNotNone(result2nn)
 
     def test_bb_inf_nn(self):
         resultinfnn = conduct(self.attack_bbinf_nn, self.nn_model, self.nn_data)
-        #print(resultinfnn)
+        self.assertIsNotNone(resultinfnn)
 

--- a/tests/test_brendel_bethge.py
+++ b/tests/test_brendel_bethge.py
@@ -8,6 +8,7 @@ import torchvision.models as tv_models
 import foolbox as fb
 from attacks.foolboxattacks.brendel_bethge import L0BrendelBethge, L1BrendelBethge, L2BrendelBethge, LinfinityBrendelBethge
 from attacks.helpers.data import Data
+from attacks.helpers.parameters import FoolboxParameters
 from attacks.foolbox_attack import FoolboxAttack
 from foolbox.utils import accuracy
 
@@ -29,7 +30,7 @@ def nn_test():
     if ss_nn_pipeline is not None:
         standard_scaler_from_nn_pipeline = ss_nn_pipeline.steps[0][1]
         nn_model = ss_nn_pipeline.steps[1][1].module_
-        
+        fmodel = fb.models.pytorch.PyTorchModel(nn_model, bounds=(-2., 30000.))
 
         csv_filename = '../data_test.csv'
 
@@ -38,18 +39,21 @@ def nn_test():
             data = list(list(line) for line in reader)
             data.pop(0)
             data2 = []
+            i = 0
             for row in data:
-                row2 = []
-                for place in range(len(row)):
-                    row2.append(float(row[place]))
-                data2.append(row2)
+                if i < 100:
+                    i = i+1
+                    row2 = []
+                    for place in range(len(row)):
+                        row2.append(float(row[place]))
+                    data2.append(row2)
             data = data2
             data = torch.tensor(data, requires_grad=False, dtype=torch.float)
             data, result = torch.hsplit(data, [91, ])
             result = torch.tensor(result, requires_grad=False, dtype=torch.float)
             data = Data(data, result)
 
-        return nn_model, data
+        return fmodel, data
     return None, None
 
 
@@ -75,38 +79,46 @@ def conduct(attack: FoolboxAttack, model, data: Data):
 
         
 def main():
-    bb_simple_args_dict = {'epsilons': 1, "lr": 1, 'steps': 100, 'min': 0, 'max': 1}
-    bb_nn_args_dict = {'epsilons': 1, "lr": 1, 'steps': 100, 'min': -1.0, 'max': 28157.0}
+    generic_parameters_simple = {'min': 0, 'max': 1}
+    generic_parameters_nn = {'min': -1.0, 'max': 28157.0}
+    attack_specific_parameters = {"lr": 10, 'steps': 100}
+    parameters_simple = FoolboxParameters(attack_specific_parameters,generic_parameters_simple)
+    parameters_nn = FoolboxParameters(attack_specific_parameters, generic_parameters_nn)
 
-    attack_bb0_simple = L0BrendelBethge(bb_simple_args_dict)
-    attack_bb1_simple = L1BrendelBethge(bb_simple_args_dict)
-    attack_bb2_simple = L2BrendelBethge(bb_simple_args_dict)
-    attack_bbinf_simple = LinfinityBrendelBethge(bb_simple_args_dict)
+    attack_bb0_simple = L0BrendelBethge(parameters_simple)
+    attack_bb1_simple = L1BrendelBethge(parameters_simple)
+    attack_bb2_simple = L2BrendelBethge(parameters_simple)
+    attack_bbinf_simple = LinfinityBrendelBethge(parameters_simple)
 
-    attack_bb1_nn = L1BrendelBethge(bb_nn_args_dict)
-    attack_bb2_nn = L2BrendelBethge(bb_nn_args_dict)
-    attack_bbinf_nn = LinfinityBrendelBethge(bb_nn_args_dict)
+    attack_bb0_nn = L0BrendelBethge(parameters_nn)
+    attack_bb1_nn = L1BrendelBethge(parameters_nn)
+    attack_bb2_nn = L2BrendelBethge(parameters_nn)
+    attack_bbinf_nn = LinfinityBrendelBethge(parameters_nn)
 
     smodel, sdata = simple_test()
 
     print("Attack bb0 simple")
-    result0 = conduct(attack_bb0_simple, smodel, sdata)
-    print(result0)
+    result0s = conduct(attack_bb0_simple, smodel, sdata)
+    print(result0s)
 
-    # print("Attack bb1 simple")
-    # result1 = conduct(attack_bb1_simple, smodel, sdata)
-    # print(result1)
+    print("Attack bb1 simple")
+    result1 = conduct(attack_bb1_simple, smodel, sdata)
+    print(result1)
 
-    # print("Attack bb2 simple")
-    # result2s = conduct(attack_bb2_simple, smodel, sdata)
-    # print(result2s)
+    print("Attack bb2 simple")
+    result2s = conduct(attack_bb2_simple, smodel, sdata)
+    print(result2s)
 
-    # print("Attack bbinf simple")
-    # resultinf = conduct(attack_bbinf_simple, smodel, sdata)
-    # print(resultinf)
+    print("Attack bbinf simple")
+    resultinfs = conduct(attack_bbinf_simple, smodel, sdata)
+    print(resultinfs)
 
     nn_model, nn_data = nn_test()
     if nn_model is not None and nn_data is not None:
+        print("Attack bb0 nn")
+        result0nn = conduct(attack_bb0_nn, nn_model, nn_data)
+        print(result0nn)
+
         print("Attack bb1 nn")
         result1nn = conduct(attack_bb1_nn, nn_model, nn_data)
         print(result1nn)

--- a/tests/test_fast_gradient.py
+++ b/tests/test_fast_gradient.py
@@ -14,6 +14,7 @@ from keras.layers import Dense, Flatten, Conv2D, MaxPooling2D
 from keras.models import Sequential
 
 from attacks.artattacks.fast_gradient import FastGradient
+from attacks.helpers.parameters import ARTParameters
 
 
 class Data:
@@ -78,7 +79,12 @@ class TestKeras(unittest.TestCase):
         model.add(Dense(100, activation="relu"))
         model.add(Dense(10, activation="softmax"))
 
-        art_attack = FastGradient(model=model, clip_values=(min_pixel_value, max_pixel_value), use_logits=False)
+        classifier_parameters = {"clip_values": (min_pixel_value, max_pixel_value),
+                                 "use_logits": False}
+        attack_parameters = {}
+        parameters = ARTParameters(classifier_parameters=classifier_parameters, attack_parameters=attack_parameters)
+
+        art_attack = FastGradient(parameters=parameters)
 
         self.assertIsNotNone(art_attack.conduct(model, data))
 
@@ -109,11 +115,15 @@ class TestPytorch(unittest.TestCase):
         criterion = nn.CrossEntropyLoss()
         optimizer = optim.Adam(model.parameters(), lr=0.01)
 
-        art_model = FastGradient(clip_values=(min_pixel_value, max_pixel_value),
-                                 loss=criterion,
-                                 optimizer=optimizer,
-                                 input_shape=(1, 28, 28),
-                                 nb_classes=10,)
+        classifier_parameters = {"clip_values": (min_pixel_value, max_pixel_value),
+                                 "loss": criterion,
+                                 "optimizer": optimizer,
+                                 "input_shape": (1, 28, 28),
+                                 "nb_classes": 10}
+        attack_parameters = {}
+        parameters=ARTParameters(classifier_parameters=classifier_parameters,attack_parameters=attack_parameters)
+
+        art_model = FastGradient(parameters)
 
         # This attack does not need y/output
         data2 = Data((np.transpose(data.input, (0, 3, 1, 2)).astype(np.float32), None))

--- a/tests/test_frameworks.py
+++ b/tests/test_frameworks.py
@@ -12,7 +12,6 @@ import eagerpy as ep
 import numpy as np
 import tensorflow
 import tensorflow.compat.v1 as tf
-import timeout_decorator
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -169,8 +168,6 @@ class TestArtWithPytorchUsingArt(unittest.TestCase):
     Checks attacks from artattacks package using example from:
     https://github.com/Trusted-AI/adversarial-robustness-toolbox/blob/main/examples/get_started_pytorch.py
     '''
-    # Zmodyfikowany czas oczekiwania, tak aby test mógł się zakończyć w 15min.
-    @timeout_decorator.timeout(900)
     def test_art_ZeorthOrderOptimalization(self):
         model = pytorch_model_form_art()
         # This is only for testing purpose as are the parameters
@@ -203,8 +200,6 @@ class TestArtWithPytorchUsingFoolbox(unittest.TestCase):
     Checks attacks from artattacks package using example from:
     https://github.com/bethgelab/foolbox/blob/master/examples/single_attack_pytorch_resnet18.py
     '''
-    @timeout_decorator.timeout(900)
-    @unittest.expectedFailure
     def test_art_ZeorthOrderOptimalization(self):
         model = pytorch_model_form_foolbox()
         classifier_parameters = {"clip_values": (_min_pixel_value, _max_pixel_value),
@@ -231,7 +226,7 @@ class TestArtWithPytorchUsingFoolbox(unittest.TestCase):
         # Czy Foolbox używa tablic? Czy kodowanie jest hot-one?
         self.assertIsNotNone(art_model.conduct(model, foolbox_sample_data()))
 
-    @timeout_decorator.timeout(120)
+
     @unittest.skip("AdversarialPatch is not yet implemented.")
     def test_art_AdversarialPatch(self):
         art_model = AdversarialPatch(ARTParameters({}, {}))
@@ -240,7 +235,6 @@ class TestArtWithPytorchUsingFoolbox(unittest.TestCase):
 
 class TestArtWithKerasUsingArt(unittest.TestCase):
     # Working example
-    @timeout_decorator.timeout(120)
     def test_keras_fast_gradient(self):
         mod = keras_model_from_art()
 
@@ -253,8 +247,7 @@ class TestArtWithKerasUsingArt(unittest.TestCase):
 
         self.assertIsNotNone(attack.conduct(mod, Data(load_mnist()[0])))
 
-    @timeout_decorator.timeout(500)
-    @unittest.skip("I dont have that much time to spare.")
+    @unittest.skip("This takes forever")
     def test_art_ZeorthOrderOptimalization(self):
         model = pytorch_model_form_art()
         classifier_parameters = {"clip_values": (_min_pixel_value, _max_pixel_value),
@@ -270,7 +263,7 @@ class TestArtWithKerasUsingArt(unittest.TestCase):
 
         self.assertIsNotNone(art_model.conduct(keras_model_from_art(), Data(load_mnist()[0])))
 
-    @timeout_decorator.timeout(120)
+
     @unittest.skip("AdversarialPatch is not yet implemented.")
     def test_art_AdversarialPatch(self):
         art_model = AdversarialPatch(ARTParameters({}, {}))
@@ -278,14 +271,14 @@ class TestArtWithKerasUsingArt(unittest.TestCase):
 
     # With tf.compat.v1.disable_eager_execution() ValueError: TensorFlowModel requires TensorFlow Eager Mode
     # Without -"- ValueError: expected model to be callable
-    @timeout_decorator.timeout(120)
+
     def test_foolbox_ProjectedGradientDescentInf(self):
-        foolbox_model = LinfProjectedGradientDescent(ARTParameters({}, {}))
+        foolbox_model = LinfProjectedGradientDescent(FoolboxParameters({}, {}))
         self.assertIsNotNone(foolbox_model.conduct(keras_model_from_art(), Data(load_mnist()[0])))
 
     # With tf.compat.v1.disable_eager_execution() ValueError: TensorFlowModel requires TensorFlow Eager Mode
     # Without -"- ValueError: expected model to be callable
-    @timeout_decorator.timeout(120)
+
     def test_foolbox_L1BasicIterative(self):
         foolbox_model = L1BasicIterative(FoolboxParameters({}, {}))
         self.assertIsNotNone(foolbox_model.conduct(keras_model_from_art(), Data(load_mnist()[0])))

--- a/tests/test_frameworks.py
+++ b/tests/test_frameworks.py
@@ -29,7 +29,8 @@ from attacks.artattacks.adversarial_patch import AdversarialPatch
 from attacks.artattacks.fast_gradient import FastGradient
 from attacks.artattacks.zeroth_order_optimization_bb_attack import ZeorthOrderOptimalization
 from attacks.foolboxattacks.basic_iterative import L1BasicIterative, L2BasicIterative, LinfBasicIterative
-from attacks.foolboxattacks.projected_gradient_descent import ProjectedGradientDescentInf
+from attacks.foolboxattacks.projected_gradient_descent import LinfProjectedGradientDescent
+from attacks.helpers.parameters import FoolboxParameters, ARTParameters
 
 tf.compat.v1.disable_eager_execution()
 
@@ -127,11 +128,11 @@ class TestFoolboxWithPytorchUsingFoolbox(unittest.TestCase):
     https://github.com/bethgelab/foolbox/blob/master/examples/single_attack_pytorch_resnet18.py
     '''
     def test_foolbox_ProjectedGradientDescentInf(self):
-        foolbox_model = ProjectedGradientDescentInf()
+        foolbox_model = LinfProjectedGradientDescent(FoolboxParameters({}, {}))
         self.assertIsNotNone(foolbox_model.conduct(pytorch_model_form_foolbox(), foolbox_sample_data()))
 
     def test_foolbox_L1BasicIterative(self):
-        foolbox_model = L1BasicIterative({})
+        foolbox_model = L1BasicIterative(FoolboxParameters({}, {}))
         self.assertIsNotNone(foolbox_model.conduct(pytorch_model_form_foolbox(), foolbox_sample_data()))
 
 
@@ -142,22 +143,22 @@ class TestFoolboxWithPytorchUsingArt(unittest.TestCase):
     https://github.com/Trusted-AI/adversarial-robustness-toolbox/blob/main/examples/get_started_pytorch.py
     '''
     def test_foolbox_ProjectedGradientDescentInf(self):
-        foolbox_model = ProjectedGradientDescentInf()
+        foolbox_model = LinfProjectedGradientDescent(FoolboxParameters({}, {}))
         self.assertIsNotNone(foolbox_model.conduct(pytorch_model_form_art(),
                                                    art_sample_data().foolbox_pytorch_preprocessing()))
 
     def test_foolbox_L1BasicIterative(self):
-        foolbox_model = L1BasicIterative({}, {})
+        foolbox_model = L1BasicIterative(FoolboxParameters({}, {}))
         self.assertIsNotNone(foolbox_model.conduct(pytorch_model_form_art(),
                                                    art_sample_data().foolbox_pytorch_preprocessing()))
 
     def test_foolbox_L2BasicIterative(self):
-        foolbox_model = L2BasicIterative({}, {})
+        foolbox_model = L2BasicIterative(FoolboxParameters({}, {}))
         self.assertIsNotNone(foolbox_model.conduct(pytorch_model_form_art(),
                                                    art_sample_data().foolbox_pytorch_preprocessing()))
 
     def test_foolbox_LinfBasicIterative(self):
-        foolbox_model = LinfBasicIterative({}, {})
+        foolbox_model = LinfBasicIterative(FoolboxParameters({}, {}))
         self.assertIsNotNone(foolbox_model.conduct(pytorch_model_form_art(),
                                                    art_sample_data().foolbox_pytorch_preprocessing()))
 
@@ -174,22 +175,26 @@ class TestArtWithPytorchUsingArt(unittest.TestCase):
         model = pytorch_model_form_art()
         # This is only for testing purpose as are the parameters
         model.cpu()
-        art_model = ZeorthOrderOptimalization(clip_values=(_min_pixel_value, _max_pixel_value),
-                                              loss=nn.CrossEntropyLoss(),
-                                              optimizer=optim.Adam(model.parameters(), lr=0.01),
-                                              input_shape=(1, 28, 28),
-                                              nb_classes=10,
-                                              nb_parallel=1,
-                                              binary_search_steps=1,
-                                              batch_size=500,
-                                              max_iter=2,
-                                            #   use_resize=False,
-                                              verbose=True)
+        classifier_parameters = {"clip_values": (_min_pixel_value, _max_pixel_value),
+                                 "loss": nn.CrossEntropyLoss(),
+                                 "optimizer": optim.Adam(model.parameters(), lr=0.01),
+                                 "input_shape": (1, 28, 28),
+                                 "nb_classes": 10}
+        attack_parameters = {"nb_parallel": 1,
+                             "binary_search_steps": 1,
+                             "batch_size": 500,
+                             "max_iter": 2,
+                             "verbose": True}
+
+        parameters = ARTParameters(classifier_parameters=classifier_parameters, attack_parameters=attack_parameters)
+
+        art_model = ZeorthOrderOptimalization(parameters=parameters)
+
         self.assertIsNotNone(art_model.conduct(pytorch_model_form_art(), art_sample_data()))
 
     @unittest.skip("AdversarialPatch is not yet implemented.")
     def test_art_AdversarialPatch(self):
-        art_model = AdversarialPatch()
+        art_model = AdversarialPatch(ARTParameters({}, {}))
         self.assertIsNotNone(art_model.conduct(pytorch_model_form_art(), art_sample_data()))
 
 
@@ -202,17 +207,20 @@ class TestArtWithPytorchUsingFoolbox(unittest.TestCase):
     @unittest.expectedFailure
     def test_art_ZeorthOrderOptimalization(self):
         model = pytorch_model_form_foolbox()
-        art_model = ZeorthOrderOptimalization(clip_values=(_min_pixel_value, _max_pixel_value),
-                                              loss=nn.CrossEntropyLoss(),
-                                              optimizer=optim.Adam(model.parameters(), lr=0.01),
-                                              input_shape=(1, 28, 28),
-                                              nb_classes=10,
-                                              nb_parallel=1,
-                                              binary_search_steps=1,
-                                              batch_size=500,
-                                              max_iter=2,
-                                            #   use_resize=False,
-                                              verbose=True)
+        classifier_parameters = {"clip_values": (_min_pixel_value, _max_pixel_value),
+                                 "loss": nn.CrossEntropyLoss(),
+                                 "optimizer": optim.Adam(model.parameters(), lr=0.01),
+                                 "input_shape": (1, 28, 28),
+                                 "nb_classes": 10}
+        attack_parameters = {"nb_parallel": 1,
+                             "binary_search_steps": 1,
+                             "batch_size": 500,
+                             "max_iter": 2,
+                             "verbose": True}
+
+        parameters = ARTParameters(classifier_parameters=classifier_parameters, attack_parameters=attack_parameters)
+
+        art_model = ZeorthOrderOptimalization(parameters=parameters)
 
         # FIXME :
         # Poniższa linijka wyrzuca błąd:
@@ -226,7 +234,7 @@ class TestArtWithPytorchUsingFoolbox(unittest.TestCase):
     @timeout_decorator.timeout(120)
     @unittest.skip("AdversarialPatch is not yet implemented.")
     def test_art_AdversarialPatch(self):
-        art_model = AdversarialPatch()
+        art_model = AdversarialPatch(ARTParameters({}, {}))
         self.assertIsNotNone(art_model.conduct(pytorch_model_form_foolbox(), foolbox_sample_data()))
 
 
@@ -236,7 +244,12 @@ class TestArtWithKerasUsingArt(unittest.TestCase):
     def test_keras_fast_gradient(self):
         mod = keras_model_from_art()
 
-        attack = FastGradient(clip_values=(_min_pixel_value, _max_pixel_value), use_logits=False)
+        classifier_parameters = {"clip_values": (_min_pixel_value, _max_pixel_value),
+                                 "use_logits": False}
+        attack_parameters = {}
+        parameters = ARTParameters(classifier_parameters=classifier_parameters, attack_parameters=attack_parameters)
+
+        attack = FastGradient(parameters=parameters)
 
         self.assertIsNotNone(attack.conduct(mod, Data(load_mnist()[0])))
 
@@ -244,31 +257,37 @@ class TestArtWithKerasUsingArt(unittest.TestCase):
     @unittest.skip("I dont have that much time to spare.")
     def test_art_ZeorthOrderOptimalization(self):
         model = pytorch_model_form_art()
-        art_model = ZeorthOrderOptimalization(clip_values=(_min_pixel_value, _max_pixel_value),
-                                              loss=nn.CrossEntropyLoss(),
-                                              optimizer=optim.Adam(model.parameters(), lr=0.01),
-                                              input_shape=(1, 28, 28),
-                                              nb_classes=10)
+        classifier_parameters = {"clip_values": (_min_pixel_value, _max_pixel_value),
+                                 "loss": nn.CrossEntropyLoss(),
+                                 "optimizer": optim.Adam(model.parameters(), lr=0.01),
+                                 "input_shape": (1, 28, 28),
+                                 "nb_classes": 10}
+        attack_parameters = {}
+
+        parameters = ARTParameters(classifier_parameters=classifier_parameters, attack_parameters=attack_parameters)
+
+        art_model = ZeorthOrderOptimalization(parameters=parameters)
+
         self.assertIsNotNone(art_model.conduct(keras_model_from_art(), Data(load_mnist()[0])))
 
     @timeout_decorator.timeout(120)
     @unittest.skip("AdversarialPatch is not yet implemented.")
     def test_art_AdversarialPatch(self):
-        art_model = AdversarialPatch()
+        art_model = AdversarialPatch(ARTParameters({}, {}))
         self.assertIsNotNone(art_model.conduct(keras_model_from_art(), Data(load_mnist()[0])))
 
     # With tf.compat.v1.disable_eager_execution() ValueError: TensorFlowModel requires TensorFlow Eager Mode
     # Without -"- ValueError: expected model to be callable
     @timeout_decorator.timeout(120)
     def test_foolbox_ProjectedGradientDescentInf(self):
-        foolbox_model = ProjectedGradientDescentInf()
+        foolbox_model = LinfProjectedGradientDescent(ARTParameters({}, {}))
         self.assertIsNotNone(foolbox_model.conduct(keras_model_from_art(), Data(load_mnist()[0])))
 
     # With tf.compat.v1.disable_eager_execution() ValueError: TensorFlowModel requires TensorFlow Eager Mode
     # Without -"- ValueError: expected model to be callable
     @timeout_decorator.timeout(120)
     def test_foolbox_L1BasicIterative(self):
-        foolbox_model = L1BasicIterative({})
+        foolbox_model = L1BasicIterative(FoolboxParameters({}, {}))
         self.assertIsNotNone(foolbox_model.conduct(keras_model_from_art(), Data(load_mnist()[0])))
 
 

--- a/tests/test_joker.py
+++ b/tests/test_joker.py
@@ -14,6 +14,7 @@ from keras.layers import Dense, Flatten, Conv2D, MaxPooling2D
 from keras.models import Sequential
 
 from attacks.artattacks.joker import Joker
+from attacks.helpers.parameters import ARTParameters
 
 
 class Data:
@@ -39,14 +40,17 @@ class TestKeras(unittest.TestCase):
         model.add(Dense(100, activation="relu"))
         model.add(Dense(10, activation="softmax"))
 
-        art_attack = Joker(joker='FastGradientMethod', clip_values=(min_pixel_value, max_pixel_value), use_logits=False)
+        classifier_parameters = {"clip_values": (min_pixel_value, max_pixel_value)}
+        attack_parameters = {}
+        parameters = ARTParameters(classifier_parameters=classifier_parameters, attack_parameters=attack_parameters)
+
+        art_attack = Joker(joker='FastGradientMethod', parameters=parameters)
 
         self.assertIsNotNone(art_attack.conduct(model, data))
 
 
 class TestPytorch(unittest.TestCase):
     def test_pytorch(self):
-        print("a")
         # declaring pytorch model
         class Net(nn.Module):
             def __init__(self):
@@ -71,15 +75,16 @@ class TestPytorch(unittest.TestCase):
         criterion = nn.CrossEntropyLoss()
         optimizer = optim.Adam(model.parameters(), lr=0.01)
 
-        art_model = Joker(joker='FastGradientMethod', clip_values=(min_pixel_value, max_pixel_value),
-                                 loss=criterion,
-                                 optimizer=optimizer,
-                                 input_shape=(1, 28, 28),
-                                 nb_classes=10,)
+        classifier_parameters = {"clip_values": (min_pixel_value, max_pixel_value),
+                                 "loss": criterion,
+                                 "optimizer": optimizer,
+                                 "input_shape": (1, 28, 28),
+                                 "nb_classes": 10}
+        attack_parameters = {}
+        parameters = ARTParameters(classifier_parameters=classifier_parameters, attack_parameters=attack_parameters)
+
+        art_model = Joker(joker='FastGradientMethod', parameters=parameters)
 
         # This attack does not need y/output
         data2 = Data((np.transpose(data.input, (0, 3, 1, 2)).astype(np.float32), None))
-
-        print("a")
-
         self.assertIsNotNone(art_model.conduct(model, data2))

--- a/tests/test_projected_gradient_descent.py
+++ b/tests/test_projected_gradient_descent.py
@@ -3,6 +3,7 @@ import mlflow
 import csv
 import numpy as np
 import torch
+import unittest
 
 import torchvision.models as tv_models
 import foolbox as fb
@@ -75,7 +76,7 @@ def conduct(attack: FoolboxAttack, model, data: Data):
     return adversarials
 
 
-def main():
+class TestProjectedGradientDescent(unittest.TestCase):
     attack_specific_parameters = {"steps": 100, "random_start": True}
     generic_parameters_simple = {"epsilon": 0.01}
     generic_parameters_nn = {"epsilon": 30}
@@ -91,50 +92,62 @@ def main():
 
     smodel, sdata = simple_test(batchsize=20)
 
-    print("Attack pgd1 simple")
-    result1s = conduct(attack_pgd1, smodel, sdata)
+    def test_pgd_1_simple(self):
+        result1s = conduct(self.attack_pgd1, self.smodel, self.sdata)
+        # print(result1s)
 
-    print("Attack pgd2 simple")
-    result2s = conduct(attack_pgd2, smodel, sdata)
+    def test_pgd_2_simple(self):
+        result2s = conduct(self.attack_pgd2, self.smodel, self.sdata)
+        # print(result2s)
 
-    print("Attack pgdinf simple")
-    resultinfs = conduct(attack_pgdinf, smodel, sdata)
+    def test_pgd_inf_simple(self):
+        resultinfs = conduct(self.attack_pgdinf, self.smodel, self.sdata)
+        # print(resultinfs)
 
-    print("Attack pgd1 with Adam simple")
-    result1as = conduct(attack_pgd1_a, smodel, sdata)
+    def test_pgd_1_a_simple(self):
+        result1s = conduct(self.attack_pgd1_a, self.smodel, self.sdata)
+        # print(result1s)
 
-    print("Attack pgd2 with Adam simple")
-    result2as = conduct(attack_pgd2_a, smodel, sdata)
+    def test_pgd_2_a_simple(self):
+        result2s = conduct(self.attack_pgd2_a, self.smodel, self.sdata)
+        # print(result2s)
 
-    print("Attack pgdinf with Adam simple")
-    resultinfas = conduct(attack_pgdinf_a, smodel, sdata)
+    def test_pgd_inf_a_simple(self):
+        resultinfs = conduct(self.attack_pgdinf_a, self.smodel, self.sdata)
+        # print(resultinfs)
 
     nn_model, nn_data = nn_test()
-    if nn_model is not None and nn_data is not None:
-        attack_pgd1 = L1ProjectedGradientDescent(parameters_nn)
-        attack_pgd2 = L2ProjectedGradientDescent(parameters_nn)
-        attack_pgdinf = LinfProjectedGradientDescent(parameters_nn)
-        attack_pgd1_a = L1AdamProjectedGradientDescent(parameters_nn)
-        attack_pgd2_a = L2AdamProjectedGradientDescent(parameters_nn)
-        attack_pgdinf_a = LinfAdamProjectedGradientDescent(parameters_nn)
 
-        print("Attack pgd1 nn")
-        result1nn = conduct(attack_pgd1, nn_model, nn_data)
+    attack_pgd1_nn = L1ProjectedGradientDescent(parameters_nn)
+    attack_pgd2_nn = L2ProjectedGradientDescent(parameters_nn)
+    attack_pgdinf_nn = LinfProjectedGradientDescent(parameters_nn)
+    attack_pgd1_a_nn = L1AdamProjectedGradientDescent(parameters_nn)
+    attack_pgd2_a_nn = L2AdamProjectedGradientDescent(parameters_nn)
+    attack_pgdinf_a_nn = LinfAdamProjectedGradientDescent(parameters_nn)
 
-        print("Attack pgd2 nn")
-        result2nn = conduct(attack_pgd2, nn_model, nn_data)
+    def test_pgd_1_nn(self):
+        result1s = conduct(self.attack_pgd1_nn, self.nn_model, self.nn_data)
+        # print(result1s)
 
-        print("Attack pgdinf nn")
-        resultinfnn = conduct(attack_pgdinf, nn_model, nn_data)
+    def test_pgd_2_nn(self):
+        result2s = conduct(self.attack_pgd2_nn, self.nn_model, self.nn_data)
+        # print(result2s)
 
-        print("Attack pgd1 with Adam nn")
-        result1ann = conduct(attack_pgd1_a, nn_model, nn_data)
+    def test_pgd_inf_nn(self):
+        resultinfs = conduct(self.attack_pgdinf_nn, self.nn_model, self.nn_data)
+        # print(resultinfs)
 
-        print("Attack pgd2 with Adam nn")
-        result2ann = conduct(attack_pgd2_a, nn_model, nn_data)
+    def test_pgd_1_a_nn(self):
+        result1s = conduct(self.attack_pgd1_a_nn, self.nn_model, self.nn_data)
+        # print(result1s)
 
-        print("Attack pgdinf with Adam nn")
-        resultinfann = conduct(attack_pgdinf_a, nn_model, nn_data)
+    def test_pgd_2_a_nn(self):
+        result2s = conduct(self.attack_pgd2_a_nn, self.nn_model, self.nn_data)
+        # print(result2s)
+
+    def test_pgd_inf_a_nn(self):
+        resultinfs = conduct(self.attack_pgdinf_a_nn, self.nn_model, self.nn_data)
+        # print(resultinfs)
 
 
 if __name__ == '__main__':

--- a/tests/test_projected_gradient_descent.py
+++ b/tests/test_projected_gradient_descent.py
@@ -9,6 +9,7 @@ import foolbox as fb
 from attacks.foolboxattacks.projected_gradient_descent import L1ProjectedGradientDescent, L2ProjectedGradientDescent, LinfProjectedGradientDescent
 from attacks.foolboxattacks.projected_gradient_descent import L1AdamProjectedGradientDescent, L2AdamProjectedGradientDescent, LinfAdamProjectedGradientDescent
 from attacks.helpers.data import Data
+from attacks.helpers.parameters import FoolboxParameters
 from attacks.foolbox_attack import FoolboxAttack
 from foolbox.utils import accuracy
 
@@ -75,67 +76,65 @@ def conduct(attack: FoolboxAttack, model, data: Data):
 
 
 def main():
-    attack_specific_args = {"steps": 10, "random_start": True}
-    generic_args = {"epsilon": 0.01}
+    attack_specific_parameters = {"steps": 100, "random_start": True}
+    generic_parameters_simple = {"epsilon": 0.01}
+    generic_parameters_nn = {"epsilon": 30}
+    parameters_simple = FoolboxParameters(attack_specific_parameters,generic_parameters_simple)
+    parameters_nn = FoolboxParameters(attack_specific_parameters, generic_parameters_nn)
 
-    attack_pgd1 = L1ProjectedGradientDescent(attack_specific_args, generic_args)
-    attack_pgd2 = L2ProjectedGradientDescent(attack_specific_args, generic_args)
-    attack_pgdinf = LinfProjectedGradientDescent(attack_specific_args, generic_args)
-    attack_pgd1_a = L1AdamProjectedGradientDescent(attack_specific_args, generic_args)
-    attack_pgd2_a = L2AdamProjectedGradientDescent(attack_specific_args, generic_args)
-    attack_pgdinf_a = LinfAdamProjectedGradientDescent(attack_specific_args, generic_args)
+    attack_pgd1 = L1ProjectedGradientDescent(parameters_simple)
+    attack_pgd2 = L2ProjectedGradientDescent(parameters_simple)
+    attack_pgdinf = LinfProjectedGradientDescent(parameters_simple)
+    attack_pgd1_a = L1AdamProjectedGradientDescent(parameters_simple)
+    attack_pgd2_a = L2AdamProjectedGradientDescent(parameters_simple)
+    attack_pgdinf_a = LinfAdamProjectedGradientDescent(parameters_simple)
 
     smodel, sdata = simple_test(batchsize=20)
 
     print("Attack pgd1 simple")
     result1s = conduct(attack_pgd1, smodel, sdata)
-    print(result1s)
 
     print("Attack pgd2 simple")
     result2s = conduct(attack_pgd2, smodel, sdata)
-    print(result2s)
 
     print("Attack pgdinf simple")
     resultinfs = conduct(attack_pgdinf, smodel, sdata)
-    print(resultinfs)
 
     print("Attack pgd1 with Adam simple")
-    result1s = conduct(attack_pgd1_a, smodel, sdata)
-    print(result1s)
+    result1as = conduct(attack_pgd1_a, smodel, sdata)
 
     print("Attack pgd2 with Adam simple")
-    result2s = conduct(attack_pgd2_a, smodel, sdata)
-    print(result2s)
+    result2as = conduct(attack_pgd2_a, smodel, sdata)
 
     print("Attack pgdinf with Adam simple")
-    resultinfs = conduct(attack_pgdinf_a, smodel, sdata)
-    print(resultinfs)
+    resultinfas = conduct(attack_pgdinf_a, smodel, sdata)
 
     nn_model, nn_data = nn_test()
     if nn_model is not None and nn_data is not None:
+        attack_pgd1 = L1ProjectedGradientDescent(parameters_nn)
+        attack_pgd2 = L2ProjectedGradientDescent(parameters_nn)
+        attack_pgdinf = LinfProjectedGradientDescent(parameters_nn)
+        attack_pgd1_a = L1AdamProjectedGradientDescent(parameters_nn)
+        attack_pgd2_a = L2AdamProjectedGradientDescent(parameters_nn)
+        attack_pgdinf_a = LinfAdamProjectedGradientDescent(parameters_nn)
+
         print("Attack pgd1 nn")
         result1nn = conduct(attack_pgd1, nn_model, nn_data)
-        print(result1nn)
 
         print("Attack pgd2 nn")
         result2nn = conduct(attack_pgd2, nn_model, nn_data)
-        print(result2nn)
 
         print("Attack pgdinf nn")
         resultinfnn = conduct(attack_pgdinf, nn_model, nn_data)
-        print(resultinfnn)
 
         print("Attack pgd1 with Adam nn")
-        result1nn = conduct(attack_pgd1_a, nn_model, nn_data)
-        print(result1nn)
+        result1ann = conduct(attack_pgd1_a, nn_model, nn_data)
 
         print("Attack pgd2 with Adam nn")
-        result2nn = conduct(attack_pgd2_a, nn_model, nn_data)
-        print(result2nn)
+        result2ann = conduct(attack_pgd2_a, nn_model, nn_data)
 
         print("Attack pgdinf with Adam nn")
-        resultinfnn = conduct(attack_pgdinf_a, nn_model, nn_data)
-        print(resultinfnn)
+        resultinfann = conduct(attack_pgdinf_a, nn_model, nn_data)
 
 
 if __name__ == '__main__':

--- a/tests/test_projected_gradient_descent.py
+++ b/tests/test_projected_gradient_descent.py
@@ -150,5 +150,3 @@ class TestProjectedGradientDescent(unittest.TestCase):
         # print(resultinfs)
 
 
-if __name__ == '__main__':
-    main()

--- a/tests/test_projected_gradient_descent.py
+++ b/tests/test_projected_gradient_descent.py
@@ -94,27 +94,27 @@ class TestProjectedGradientDescent(unittest.TestCase):
 
     def test_pgd_1_simple(self):
         result1s = conduct(self.attack_pgd1, self.smodel, self.sdata)
-        # print(result1s)
+        self.assertIsNotNone(result1s)
 
     def test_pgd_2_simple(self):
         result2s = conduct(self.attack_pgd2, self.smodel, self.sdata)
-        # print(result2s)
+        self.assertIsNotNone(result2s)
 
     def test_pgd_inf_simple(self):
         resultinfs = conduct(self.attack_pgdinf, self.smodel, self.sdata)
-        # print(resultinfs)
+        self.assertIsNotNone(resultinfs)
 
     def test_pgd_1_a_simple(self):
         result1s = conduct(self.attack_pgd1_a, self.smodel, self.sdata)
-        # print(result1s)
+        self.assertIsNotNone(result1s)
 
     def test_pgd_2_a_simple(self):
         result2s = conduct(self.attack_pgd2_a, self.smodel, self.sdata)
-        # print(result2s)
+        self.assertIsNotNone(result2s)
 
     def test_pgd_inf_a_simple(self):
         resultinfs = conduct(self.attack_pgdinf_a, self.smodel, self.sdata)
-        # print(resultinfs)
+        self.assertIsNotNone(resultinfs)
 
     nn_model, nn_data = nn_test()
 
@@ -127,26 +127,26 @@ class TestProjectedGradientDescent(unittest.TestCase):
 
     def test_pgd_1_nn(self):
         result1s = conduct(self.attack_pgd1_nn, self.nn_model, self.nn_data)
-        # print(result1s)
+        self.assertIsNotNone(result1s)
 
     def test_pgd_2_nn(self):
         result2s = conduct(self.attack_pgd2_nn, self.nn_model, self.nn_data)
-        # print(result2s)
+        self.assertIsNotNone(result2s)
 
     def test_pgd_inf_nn(self):
         resultinfs = conduct(self.attack_pgdinf_nn, self.nn_model, self.nn_data)
-        # print(resultinfs)
+        self.assertIsNotNone(resultinfs)
 
     def test_pgd_1_a_nn(self):
         result1s = conduct(self.attack_pgd1_a_nn, self.nn_model, self.nn_data)
-        # print(result1s)
+        self.assertIsNotNone(result1s)
 
     def test_pgd_2_a_nn(self):
         result2s = conduct(self.attack_pgd2_a_nn, self.nn_model, self.nn_data)
-        # print(result2s)
+        self.assertIsNotNone(result2s)
 
     def test_pgd_inf_a_nn(self):
         resultinfs = conduct(self.attack_pgdinf_a_nn, self.nn_model, self.nn_data)
-        # print(resultinfs)
+        self.assertIsNotNone(resultinfs)
 
 

--- a/tests/test_salt_and_pepper.py
+++ b/tests/test_salt_and_pepper.py
@@ -5,6 +5,7 @@ import mlflow
 import csv
 import numpy as np
 import torch
+import unittest
 
 import torchvision.models as tv_models
 import foolbox as fb
@@ -79,7 +80,7 @@ def conduct(attack: SaltAndPepperNoise, model, data: Data):
     return adversarials
 
 
-def main():
+class TestSaltAndPepper(unittest.TestCase):
     attack_specific_parameters_simple = {"steps": 10, "across_channels": True}
     attack_specific_parameters_nn = {"steps": 100, "across_channels": True}
     generic_parameters_simple = {}
@@ -91,23 +92,19 @@ def main():
     attack_sap_simple = SaltAndPepperNoise(parameters_simple)
     attack_sap_nn = SaltAndPepperNoise(parameters_nn)
 
-    smodel, sdata = simple_test(batchsize=4)
+    def test_sap_simple_smaller(self):
+        smodel, sdata = simple_test(batchsize=4)
+        result1s = conduct(self.attack_sap_simple, smodel, sdata)
+        # print(result1s)
 
-    print("Attack salt and pepper simple with tiny batchsize")
-    result1s = conduct(attack_sap_simple, smodel, sdata)
+    def test_sap_simple_larger(self):
+        smodel, sdata = simple_test(batchsize=20)
+        result2s = conduct(self.attack_sap_simple, smodel, sdata)
+        # print(result2s)
 
-    smodel, sdata = simple_test(batchsize=20)
-
-    print("Attack salt and pepper simple with sligtly larger batchsize")
-    result2s = conduct(attack_sap_simple, smodel, sdata)
-
-
-    nn_model, nn_data = nn_test()
-    if nn_model is not None and nn_data is not None:
-        print("Attack salt and pepper nn")
-        result1nn = conduct(attack_sap_nn, nn_model, nn_data)
-
+    def test_sap_nn(self):
+        nn_model, nn_data = nn_test()
+        resultnn = conduct(self.attack_sap_nn, nn_model, nn_data)
+        # print(resultnn)
 
 
-if __name__ == '__main__':
-    main()

--- a/tests/test_salt_and_pepper.py
+++ b/tests/test_salt_and_pepper.py
@@ -95,16 +95,16 @@ class TestSaltAndPepper(unittest.TestCase):
     def test_sap_simple_smaller(self):
         smodel, sdata = simple_test(batchsize=4)
         result1s = conduct(self.attack_sap_simple, smodel, sdata)
-        # print(result1s)
+        self.assertIsNotNone(result1s)
 
     def test_sap_simple_larger(self):
         smodel, sdata = simple_test(batchsize=20)
         result2s = conduct(self.attack_sap_simple, smodel, sdata)
-        # print(result2s)
+        self.assertIsNotNone(result2s)
 
     def test_sap_nn(self):
         nn_model, nn_data = nn_test()
         resultnn = conduct(self.attack_sap_nn, nn_model, nn_data)
-        # print(resultnn)
+        self.assertIsNotNone(resultnn)
 
 

--- a/tests/test_salt_and_pepper.py
+++ b/tests/test_salt_and_pepper.py
@@ -9,6 +9,7 @@ import torch
 import torchvision.models as tv_models
 import foolbox as fb
 from attacks.helpers.data import Data
+from attacks.helpers.parameters import FoolboxParameters
 from attacks.foolbox_attack import FoolboxAttack
 from foolbox.utils import accuracy
 
@@ -42,7 +43,7 @@ def nn_test():
             data2 = []
             i = 0
             for row in data:
-                if i < 10000:
+                if i < 100:
                     i = i+1
                     row2 = []
                     for place in range(len(row)):
@@ -79,13 +80,16 @@ def conduct(attack: SaltAndPepperNoise, model, data: Data):
 
 
 def main():
-    attack_specific_args_simple = {"steps": 10, "across_channels": False}
-    generic_args = {}
+    attack_specific_parameters_simple = {"steps": 10, "across_channels": True}
+    attack_specific_parameters_nn = {"steps": 100, "across_channels": True}
+    generic_parameters_simple = {}
+    generic_parameters_nn = {}
+    parameters_simple = FoolboxParameters(attack_specific_parameters_simple, generic_parameters_simple)
+    parameters_nn = FoolboxParameters(attack_specific_parameters_nn, generic_parameters_nn)
 
-    attack_specific_args_nn = {"steps": 1000, "across_channels": False}
 
-    attack_sap_simple = SaltAndPepperNoise(attack_specific_args_simple, generic_args)
-    attack_sap_nn = SaltAndPepperNoise(attack_specific_args_nn, generic_args)
+    attack_sap_simple = SaltAndPepperNoise(parameters_simple)
+    attack_sap_nn = SaltAndPepperNoise(parameters_nn)
 
     smodel, sdata = simple_test(batchsize=4)
 

--- a/tests/test_zoo.py
+++ b/tests/test_zoo.py
@@ -96,7 +96,6 @@ class ZooTestUsingPytorchArt__potential_failure(unittest.TestCase):
                              "binary_search_steps": 1,
                              "batch_size": 500,
                              "max_iter": 1,
-                             "use_resize": False,
                              "verbose": True}
         parameters = ARTParameters(classifier_parameters=classifier_parameters, attack_parameters=attack_parameters)
 

--- a/tests/test_zoo.py
+++ b/tests/test_zoo.py
@@ -9,7 +9,7 @@ import torch.optim as optim
 from art.utils import load_mnist
 
 
-
+from attacks.helpers.parameters import ARTParameters
 from attacks.artattacks.zeroth_order_optimization_bb_attack import ZeorthOrderOptimalization
 
 
@@ -68,17 +68,20 @@ class ZooTestUsingPytorchArt(unittest.TestCase):
         model = pytorch_model_form_art()
         # This is only for testing purpose as are the parameters
         model.cpu()
-        art_model = ZeorthOrderOptimalization(clip_values=(_min_pixel_value, _max_pixel_value),
-                                              loss=nn.CrossEntropyLoss(),
-                                              optimizer=optim.Adam(model.parameters(), lr=0.01),
-                                              input_shape=(1, 28, 28),
-                                              nb_classes=10,
-                                              nb_parallel=1,
-                                              binary_search_steps=1,
-                                              batch_size=1000,
-                                              max_iter=1,
-                                            #   use_resize=False,
-                                              verbose=True)
+        classifier_parameters = {"clip_values": (_min_pixel_value, _max_pixel_value),
+                                 "loss": nn.CrossEntropyLoss(),
+                                 "optimizer": optim.Adam(model.parameters(), lr=0.01),
+                                 "input_shape": (1, 28, 28),
+                                 "nb_classes": 10}
+        attack_parameters = {"nb_parallel": 1,
+                             "binary_search_steps": 1,
+                             "batch_size": 1000,
+                             "max_iter": 1,
+                             "verbose": True}
+        parameters = ARTParameters(classifier_parameters=classifier_parameters, attack_parameters=attack_parameters)
+
+        art_model = ZeorthOrderOptimalization(parameters=parameters)
+
         self.assertIsNotNone(art_model.conduct(pytorch_model_form_art(), art_sample_data()))
 
 class ZooTestUsingPytorchArt__potential_failure(unittest.TestCase):
@@ -87,15 +90,19 @@ class ZooTestUsingPytorchArt__potential_failure(unittest.TestCase):
         model = pytorch_model_form_art()
         # This is only for testing purpose as are the parameters
         model.cpu()
-        art_model = ZeorthOrderOptimalization(clip_values=(_min_pixel_value, _max_pixel_value),
-                                              loss=nn.CrossEntropyLoss(),
-                                              optimizer=optim.Adam(model.parameters(), lr=0.01),
-                                              input_shape=(1, 28, 28),
-                                              nb_classes=10,
-                                              nb_parallel=1,
-                                              binary_search_steps=1,
-                                              batch_size=500,
-                                              max_iter=1,
-                                              use_resize=False,
-                                              verbose=True)
+        classifier_parameters = {"clip_values": (_min_pixel_value, _max_pixel_value),
+                                 "loss": nn.CrossEntropyLoss(),
+                                 "optimizer": optim.Adam(model.parameters(), lr=0.01),
+                                 "input_shape": (1, 28, 28),
+                                 "nb_classes": 10}
+        attack_parameters = {"nb_parallel": 1,
+                             "binary_search_steps": 1,
+                             "batch_size": 500,
+                             "max_iter": 1,
+                             "use_resize": False,
+                             "verbose": True}
+        parameters = ARTParameters(classifier_parameters=classifier_parameters, attack_parameters=attack_parameters)
+
+        art_model = ZeorthOrderOptimalization(parameters=parameters)
+
         self.assertIsNotNone(art_model.conduct(pytorch_model_form_art(), art_sample_data()))

--- a/tests/test_zoo.py
+++ b/tests/test_zoo.py
@@ -1,7 +1,6 @@
 import unittest
 
 import numpy as np
-import timeout_decorator
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -63,7 +62,6 @@ def art_sample_data():
 
 
 class ZooTestUsingPytorchArt(unittest.TestCase):
-    @timeout_decorator.timeout(900)
     def test_art_ZeorthOrderOptimalization(self):
         model = pytorch_model_form_art()
         # This is only for testing purpose as are the parameters
@@ -85,7 +83,6 @@ class ZooTestUsingPytorchArt(unittest.TestCase):
         self.assertIsNotNone(art_model.conduct(pytorch_model_form_art(), art_sample_data()))
 
 class ZooTestUsingPytorchArt__potential_failure(unittest.TestCase):
-    @timeout_decorator.timeout(900)
     def test_art_ZeorthOrderOptimalization(self):
         model = pytorch_model_form_art()
         # This is only for testing purpose as are the parameters


### PR DESCRIPTION
**Main changes:**
- Added the "FoolboxParameters" and "ARTParameters" classes, both descended from a "Parameters" class
- Changed all attacks and tests, so that they all use the classes mentioned

**Additional changes:**
- Changed Brendel-Bethge attack, so that it fits the implementation of other Foolbox attacks
- Modified some of the default parameters in Foolbox tests to make the tests give better results.
- Added the verify_bounds function from Brendel Bethge to other foolbox attacks, since it is a good idea. This function automatically sets min and max values if they are not provided, based on the smallest and the biggest value included in the input provided.
- Added the verify_epsilon function to foolbox attacks, which automatically sets epsilon value if it isn't provided; the default value is (max-min)*0.001
- Refactored foolbox tests to use unittest, so that all tests can be ran at once.